### PR TITLE
chore: turn on unbound-method

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -93,6 +93,7 @@ module.exports = {
     "@typescript-eslint/no-unsafe-enum-comparison": "warn",
     "@typescript-eslint/no-unsafe-member-access": "warn",
     "@typescript-eslint/no-unsafe-return": "warn",
+    "@typescript-eslint/unbound-method": "error",
     "import/consistent-type-specifier-style": "warn",
     "import/no-cycle": "error",
     "import/order": [
@@ -158,7 +159,6 @@ module.exports = {
     "@typescript-eslint/no-non-null-assertion": "off",
     "@typescript-eslint/no-unnecessary-type-assertion": "off",
     "@typescript-eslint/no-redundant-type-constituents": "off",
-    "@typescript-eslint/unbound-method": "off",
     "sonarjs/no-duplicate-string": "off",
     "tailwindcss/no-custom-classname": "off",
     "vue/multi-word-component-names": "off",

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -93,7 +93,6 @@ module.exports = {
     "@typescript-eslint/no-unsafe-enum-comparison": "warn",
     "@typescript-eslint/no-unsafe-member-access": "warn",
     "@typescript-eslint/no-unsafe-return": "warn",
-    "@typescript-eslint/unbound-method": "error",
     "import/consistent-type-specifier-style": "warn",
     "import/no-cycle": "error",
     "import/order": [


### PR DESCRIPTION
## Description
[This rule](https://typescript-eslint.io/rules/unbound-method/) is a part of ["plugin:@typescript-eslint/recommended-type-checked"](https://typescript-eslint.io/users/configs#recommended-type-checked). To turn it on need just delete it.

Before:
![no_error](https://github.com/user-attachments/assets/88f89816-87be-4aa3-ac16-abea502e8f84)

Now:
![error](https://github.com/user-attachments/assets/524f8360-9648-4562-a305-2efdbec832b5)

If you really need it:
![if needed](https://github.com/user-attachments/assets/b01da76d-395b-4759-8a87-290684151296)


## References
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-1894
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.7.0-pr-1365-f3ce-f3cee35c.zip