### PR TITLE
fix: long file name

### DIFF
--- a/client-app/ui-kit/components/molecules/file/vc-file.vue
+++ b/client-app/ui-kit/components/molecules/file/vc-file.vue
@@ -155,7 +155,7 @@ const fileSize = computed(() => getFileSize(props.file.size));
   }
 
   &__link {
-    @apply text-[--link-color] cursor-pointer break-all;
+    @apply text-[--link-color] cursor-pointer;
 
     &:hover {
       @apply text-[--link-hover-color];
@@ -164,7 +164,7 @@ const fileSize = computed(() => getFileSize(props.file.size));
 
   &__name,
   &__link {
-    @apply grow line-clamp-2 break-words text-sm font-bold;
+    @apply grow line-clamp-2 break-all text-sm font-bold;
   }
 
   &__size {
@@ -188,7 +188,7 @@ const fileSize = computed(() => getFileSize(props.file.size));
   }
 
   &__buttons {
-    @apply flex-none flex self-start;
+    @apply flex-none flex self-center;
   }
 }
 </style>


### PR DESCRIPTION
## Description
This is a "better version" of #1311: this PR fixes case with file names without a link (for example, if file was removed from backend) and makes remove button centered, so it doesn't look weird

### Before
![Screenshot bug with text before](https://github.com/user-attachments/assets/a28b3669-9538-4b93-b85e-28bf1c7c4577)
![Screenshot with uncetered button before](https://github.com/user-attachments/assets/6d196a63-7d3c-4ee3-9b62-abff81468013)

### After
![Screenshot of fixed version](https://github.com/user-attachments/assets/6ad1eee3-9291-41f5-b5a2-7c3a23d4597e)


## References
### Jira-link:
<!-- Put link to your task in Jira here -->
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.9.0-pr-1413-4966-49660592.zip