### PR TITLE
fix: missed quote metadata localization key

### DIFF
--- a/client-app/modules/quotes/locales/en.json
+++ b/client-app/modules/quotes/locales/en.json
@@ -1,7 +1,7 @@
 {
   "quotes": {
     "meta": {
-      "title": "@:pages.account.quotes.title",
+      "title": "@:quotes.title",
       "table_description": "requested quotes"
     },
     "title": "Quote Requests",


### PR DESCRIPTION
## Description
Localization key used for quote metadata was missed because of previous refactoring

### Before
![Screenshot before fix](https://github.com/user-attachments/assets/95995910-7ecf-433f-b906-b4ba14787e49)

### After
![Screenshot after fix](https://github.com/user-attachments/assets/f3db41be-a710-4558-9c3b-a6135c4e8474)

## References
### Jira-link:
<!-- Put link to your task in Jira here -->
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.9.0-pr-1414-776d-776d4bf6.zip