### PR TITLE
fix: quote price isn't updated after negotiation with seller

### DIFF
--- a/client-app/modules/quotes/components/quote-line-items.vue
+++ b/client-app/modules/quotes/components/quote-line-items.vue
@@ -25,6 +25,7 @@
         :name="item.name"
         :route="getRoute(item)"
         :properties="getProperties(item)"
+        :actual-price="item.selectedTierPrice?.price"
         :list-price="item.listPrice"
         :total="item.extendedPrice"
         with-image


### PR DESCRIPTION
## Description
### How to reproduce
1. Create a quote
2. Update quote line item price from admin

![Screenshot of admin panel](https://github.com/user-attachments/assets/77a4082c-e472-498e-a394-ae41d65c8d52)

### Expected result:
Price will be updated on frontend too

### Actual result:
Price remains the same

### Before
![Screenshot with bug](https://github.com/user-attachments/assets/32e7def6-2711-41db-9c9f-265c2178077a)

### After
![Screenshot with fix](https://github.com/user-attachments/assets/bc18d402-3a08-4f6c-be15-f5369d47d051)


## References
### Jira-link:
<!-- Put link to your task in Jira here -->
https://virtocommerce.atlassian.net/browse/VCST-2211
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.9.0-pr-1415-888a-888a791b.zip