### PR TITLE
fix: don't send recentlyBrowsed request if module is not installed/enabled

### DIFF
--- a/client-app/core/composables/useHistoricalEvents.ts
+++ b/client-app/core/composables/useHistoricalEvents.ts
@@ -1,10 +1,8 @@
 import { pushHistoricalEvent as pushHistoricalEventMutation } from "@/core/api/graphql/common/mutations";
-import { MODULE_ID_XRECOMMEND } from "@/core/constants/modules";
+import { MODULE_ID_XRECOMMEND, XRECOMMEND_ENABLED_KEY } from "@/core/constants/modules";
 import { useUser } from "@/shared/account/composables/useUser";
 import { useModuleSettings } from "./useModuleSettings";
 import type { InputPushHistoricalEventType } from "../api/graphql/types";
-
-const XRECOMMEND_ENABLED_KEY = "XRecommend.RecommendationsEnabled";
 
 export function useHistoricalEvents() {
   const { isAuthenticated } = useUser();

--- a/client-app/core/constants/modules.ts
+++ b/client-app/core/constants/modules.ts
@@ -1,5 +1,6 @@
 export const MODULE_ID_PUSH_MESSAGES = "VirtoCommerce.PushMessages";
 export const MODULE_ID_XRECOMMEND = "VirtoCommerce.XRecommend";
+export const XRECOMMEND_ENABLED_KEY = "XRecommend.RecommendationsEnabled";
 
 export const MODULE_XAPI_KEYS = {
   MODULE_ID: "VirtoCommerce.Xapi",

--- a/client-app/pages/cart.vue
+++ b/client-app/pages/cart.vue
@@ -142,6 +142,8 @@ import { computed, inject, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { recentlyBrowsed } from "@/core/api/graphql";
 import { useBreadcrumbs, useGoogleAnalytics, usePageHead } from "@/core/composables";
+import { useModuleSettings } from "@/core/composables/useModuleSettings";
+import { MODULE_ID_XRECOMMEND, XRECOMMEND_ENABLED_KEY } from "@/core/constants/modules";
 import { configInjectionKey } from "@/core/injection-keys";
 import { useUser } from "@/shared/account";
 import { useFullCart, useCoupon } from "@/shared/cart";
@@ -190,6 +192,8 @@ const { loading: loadingCheckout, comment, isValidShipment, isValidPayment, init
 const { couponCode, couponIsApplied, couponValidationError, applyCoupon, removeCoupon, clearCouponValidationError } =
   useCoupon();
 
+const { isEnabled: isEnabledXRecommend } = useModuleSettings(MODULE_ID_XRECOMMEND);
+
 const { sidebarWidgets } = useCartExtensionPoints();
 
 usePageHead({
@@ -237,7 +241,8 @@ void (async () => {
     await initialize();
   }
 
-  if (isAuthenticated.value) {
+  const isXRecommendModuleEnabled = isEnabledXRecommend(XRECOMMEND_ENABLED_KEY);
+  if (isAuthenticated.value && isXRecommendModuleEnabled) {
     recentlyBrowsedProducts.value = (await recentlyBrowsed())?.products || [];
   }
 })();


### PR DESCRIPTION
fix: do not send recently browsed request if module is not installed or disabled

## Description

## References
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-2175
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.9.0-pr-1422-785e-785ee930.zip