### PR TITLE
feat: get Quote module file scope from the Platform

### DIFF
--- a/client-app/config/settings_data.json
+++ b/client-app/config/settings_data.json
@@ -7,9 +7,6 @@
 
     "push_messages_enabled": true,
 
-    "quotes_enabled": true,
-    "quotes_files_scope": "quote-attachments",
-
     "product_compare_enabled": true,
     "product_compare_limit": 5,
     "product_filters_sorting": false,

--- a/client-app/core/types/theme-config.ts
+++ b/client-app/core/types/theme-config.ts
@@ -164,9 +164,6 @@ export interface IThemeConfigSettings {
   push_messages_enabled?: boolean;
   files_enabled?: boolean;
 
-  quotes_enabled?: boolean;
-  quotes_files_scope?: string;
-
   bulk_order_enabled?: boolean;
   product_compare_enabled?: boolean;
   product_compare_limit?: number;

--- a/client-app/modules/quotes/constants.ts
+++ b/client-app/modules/quotes/constants.ts
@@ -1,2 +1,3 @@
 export const MODULE_ID = "VirtoCommerce.Quote";
 export const ENABLED_KEY = "Quotes.EnableQuotes";
+export const FILE_UPLOAD_SCOPE_NAME = "Quotes.FileUploadScopeName";

--- a/client-app/modules/quotes/index.ts
+++ b/client-app/modules/quotes/index.ts
@@ -1,5 +1,5 @@
 import { defineAsyncComponent } from "vue";
-import { useNavigations, useThemeContext } from "@/core/composables";
+import { useNavigations } from "@/core/composables";
 import { useLanguages } from "@/core/composables/useLanguages";
 import { useModuleSettings } from "@/core/composables/useModuleSettings";
 import { MODULE_ID, ENABLED_KEY } from "@/modules/quotes/constants";
@@ -18,7 +18,6 @@ const { isEnabled } = useModuleSettings(MODULE_ID);
 const { mergeMenuSchema } = useNavigations();
 const { registerSidebarWidget } = useCartExtensionPoints();
 const { loadModuleLocale } = useLanguages();
-const { themeContext } = useThemeContext();
 
 const route: RouteRecordRaw = {
   path: "quotes",
@@ -77,7 +76,7 @@ const menuItems: DeepPartial<MenuType> = {
 };
 
 export function init(router: Router, i18n: I18n) {
-  if (themeContext.value.settings.quotes_enabled && isEnabled(ENABLED_KEY)) {
+  if (isEnabled(ENABLED_KEY)) {
     router.addRoute("Account", route);
     mergeMenuSchema(menuItems);
     void loadModuleLocale(i18n, "quotes");

--- a/client-app/modules/quotes/pages/edit-quote.vue
+++ b/client-app/modules/quotes/pages/edit-quote.vue
@@ -115,16 +115,17 @@ import { toTypedSchema } from "@vee-validate/yup";
 import { computedEager } from "@vueuse/core";
 import { cloneDeep, every, isEqual, remove } from "lodash";
 import { useField } from "vee-validate";
-import { computed, inject, onMounted, ref, watchEffect } from "vue";
+import { computed, onMounted, ref, watchEffect } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRouter } from "vue-router";
 import { string } from "yup";
 import { useBreadcrumbs, usePageHead } from "@/core/composables";
+import { useModuleSettings } from "@/core/composables/useModuleSettings";
 import { DEFAULT_NOTIFICATION_DURATION } from "@/core/constants";
 import { AddressType } from "@/core/enums";
-import { configInjectionKey } from "@/core/injection-keys";
 import { asyncForEach, isEqualAddresses } from "@/core/utilities";
-import { DEFAULT_QUOTE_FILES_SCOPE, useUser, useUserAddresses } from "@/shared/account";
+import { FILE_UPLOAD_SCOPE_NAME, MODULE_ID } from "@/modules/quotes/constants";
+import { useUser, useUserAddresses } from "@/shared/account";
 import { SelectAddressModal } from "@/shared/checkout";
 import { useOrganizationAddresses } from "@/shared/company";
 import { downloadFile, useFiles } from "@/shared/files";
@@ -144,7 +145,6 @@ interface IProps {
 
 const props = defineProps<IProps>();
 
-const config = inject(configInjectionKey, {});
 const router = useRouter();
 const { t } = useI18n();
 const { openModal, closeModal } = useModal();
@@ -175,6 +175,11 @@ const {
   submitQuote,
   updateAttachments,
 } = useUserQuote();
+
+const DEFAULT_QUOTE_FILES_SCOPE = "quote-attachments";
+const { getSettingValue } = useModuleSettings(MODULE_ID);
+const quoteFilesScope = getSettingValue(FILE_UPLOAD_SCOPE_NAME);
+
 const {
   files,
   attachedAndUploadedFiles,
@@ -186,7 +191,7 @@ const {
   removeFiles,
   fetchOptions: fetchFileOptions,
   options: fileOptions,
-} = useFiles(config.quotes_files_scope ?? DEFAULT_QUOTE_FILES_SCOPE, attachedFiles);
+} = useFiles(quoteFilesScope ? String(quoteFilesScope) : DEFAULT_QUOTE_FILES_SCOPE, attachedFiles);
 const notifications = useNotifications();
 
 usePageHead({

--- a/client-app/shared/account/constants/index.ts
+++ b/client-app/shared/account/constants/index.ts
@@ -1,1 +1,0 @@
-export const DEFAULT_QUOTE_FILES_SCOPE = "quote-attachments";

--- a/client-app/shared/account/index.ts
+++ b/client-app/shared/account/index.ts
@@ -1,4 +1,3 @@
 export * from "./components";
 export * from "./composables";
-export * from "./constants";
 export * from "./types";


### PR DESCRIPTION
## Description
Removed settings quotes_enabled and quotes_files_scope from settings_data.json

This part is configurable from the platform now 
![image](https://github.com/user-attachments/assets/d5289c78-f9a2-4d6e-9362-5e11e2d12ad1)
![image](https://github.com/user-attachments/assets/4993106c-c880-46db-bab8-c111244779ff)

Comparable with the Platform v 3.861.0 and vc-module-quote 3.818.0

## References
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-1868
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.9.0-pr-1432-3904-39042c13.zip