### PR TITLE
chore: update builder.io/sdk-vue ^1.0.36 -> ^3.0.0

### DIFF
--- a/client-app/pages/matcher/builderIo/builder-io.vue
+++ b/client-app/pages/matcher/builderIo/builder-io.vue
@@ -10,7 +10,6 @@ import { useElementVisibility } from "@vueuse/core";
 import { onMounted, ref, shallowRef, watchEffect } from "vue";
 import { onBeforeRouteUpdate } from "vue-router";
 import { usePageHead } from "@/core/composables";
-import { IS_DEVELOPMENT } from "@/core/constants";
 import { builderIOComponents } from "./customComponents";
 import type { StateType } from "../priorityManager";
 import type { BuilderContent } from "@builder.io/sdk-vue";
@@ -28,8 +27,8 @@ const emit = defineEmits<IEmits>();
 
 const props = defineProps<IProps>();
 
-const canShowContent = shallowRef(false);
-const content = shallowRef<BuilderContent | null>(null);
+const canShowContent = ref(false);
+const content = ref<BuilderContent | null>(null);
 const isLoading = ref(false);
 
 function clearState() {
@@ -57,7 +56,6 @@ async function tryLoadContent(urlPath: string) {
 
     content.value = await fetchOneEntry({
       model: "page",
-      cacheSeconds: IS_DEVELOPMENT ? 1 : 60,
       apiKey: props.apiKey,
       options: getBuilderSearchParams(new URLSearchParams(location.search)),
       userAttributes: {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.10.5",
-    "@builder.io/sdk-vue": "^1.0.36",
+    "@builder.io/sdk-vue": "^3.0.0",
     "@floating-ui/vue": "^1.1.4",
     "@headlessui/vue": "^1.7.22",
     "@tailwindcss/container-queries": "^0.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1396,14 +1396,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@builder.io/sdk-vue@npm:^1.0.36":
-  version: 1.1.2
-  resolution: "@builder.io/sdk-vue@npm:1.1.2"
+"@builder.io/sdk-vue@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@builder.io/sdk-vue@npm:3.0.0"
   dependencies:
     isolated-vm: "npm:^5.0.0"
   peerDependencies:
     vue: ">= 3"
-  checksum: 10c0/792eea44900f1e5e25ad17c22532c210ed5e5cf2bcbaf539be0bcf8214e84396ca331806184fa12bd313cda08301c96c260567d6553e4260c1c94c33ac7f7b6f
+  checksum: 10c0/3ff7c73198f9da651957fe3b167835135f0395eb42044fe35b9307816301b9e723f436f83b93d0400ba32acb29827faac9707356e5126ff92c604549531bee46
   languageName: node
   linkType: hard
 
@@ -14856,7 +14856,7 @@ __metadata:
   resolution: "vc-theme-b2b-vue@workspace:."
   dependencies:
     "@apollo/client": "npm:^3.10.5"
-    "@builder.io/sdk-vue": "npm:^1.0.36"
+    "@builder.io/sdk-vue": "npm:^3.0.0"
     "@commitlint/cli": "npm:^19.3.0"
     "@commitlint/config-conventional": "npm:^19.2.2"
     "@floating-ui/vue": "npm:^1.1.4"


### PR DESCRIPTION
## Description
Removed cache settings
https://github.com/BuilderIO/builder/blob/83f46fd6adbd181a2c7c2011b8d0bd3909ab3332/packages/core/src/builder.class.ts#L326

Braking change:
https://github.com/BuilderIO/builder/releases/tag/%40builder.io%2Fsdk-vue%402.0.0
https://github.com/BuilderIO/builder/releases/tag/%40builder.io%2Fsdk-vue%403.0.0

## References
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-2322
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.10.0-pr-1469-5433-5433c5f1.zip