### PR TITLE
fix: show single alert data changed on another tab

### DIFF
--- a/client-app/broadcast.ts
+++ b/client-app/broadcast.ts
@@ -111,6 +111,7 @@ export function setupBroadcastGlobalListeners() {
   on(dataChangedEvent, () => {
     notifications.warning({
       text: t("common.messages.data_changed"),
+      single: true,
     });
   });
 }


### PR DESCRIPTION
## Description

Show single alert data changed on another tab

## References
### Jira-link:

https://virtocommerce.atlassian.net/browse/VCST-2508

### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.12.0-pr-1517-bb05-bb059570.zip