### PR TITLE
fix: hide order status selector label on filters popup for empty orders list

### DIFF
--- a/client-app/shared/account/components/mobile-orders-filter.vue
+++ b/client-app/shared/account/components/mobile-orders-filter.vue
@@ -1,7 +1,7 @@
 <template>
   <!-- Mobile filters -->
   <div v-if="isMobile" class="flex flex-col gap-4 lg:gap-5">
-    <VcWidget v-if="!!facets" :title="$t('shared.account.orders_filter.status_label')" size="sm" collapsible>
+    <VcWidget v-if="facets?.length" :title="$t('shared.account.orders_filter.status_label')" size="sm" collapsible>
       <VcCheckboxGroup v-model="filterData.statuses" class="space-y-4">
         <VcCheckbox
           v-for="facet in statusFacet?.items"

--- a/client-app/shared/account/components/orders-filter.vue
+++ b/client-app/shared/account/components/orders-filter.vue
@@ -16,7 +16,7 @@
           <slot name="buyerNameFilterType" />
         </div>
 
-        <div v-if="!!facets">
+        <div v-if="facets?.length">
           <VcLabel>{{ $t("shared.account.orders_filter.status_label") }}</VcLabel>
 
           <VcCheckboxGroup v-model="filterData.statuses" class="mt-2 space-y-3.5">


### PR DESCRIPTION
## Description

Hide order status selector label on filters popup for empty orders list

## References
### Jira-link:

https://virtocommerce.atlassian.net/browse/VCST-2864

### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.17.0-pr-1627-1faf-1faf00cd.zip