### PR TITLE
fix: actions buttons for related products with multiple images

### DIFF
--- a/client-app/ui-kit/components/organisms/product-image/vc-product-image.vue
+++ b/client-app/ui-kit/components/organisms/product-image/vc-product-image.vue
@@ -67,11 +67,11 @@
 
     <component :is="to ? 'router-link' : 'div'" v-else :to="to" class="contents">
       <VcImage :src="images[0]?.url ?? imgSrc" :alt="alt" size-suffix="md" class="vc-product-image__img" :lazy="lazy" />
-
-      <span v-if="!!$slots.default" class="vc-product-image__slot">
-        <slot />
-      </span>
     </component>
+
+    <span v-if="!!$slots.default" class="vc-product-image__slot">
+      <slot />
+    </span>
   </div>
 </template>
 


### PR DESCRIPTION
## Description
Before:
![image](https://github.com/user-attachments/assets/0b5a8b7c-ebe5-4aaa-9efb-febcb721b4df)
![image](https://github.com/user-attachments/assets/c8694316-831f-469a-99ef-0069c8ad5c59)


After:
![image](https://github.com/user-attachments/assets/a6bab96b-6107-4bdd-81ef-7624ecb3e4dd)
![image](https://github.com/user-attachments/assets/a84ab375-5c40-4d5b-9593-4aafb0756e0a)



## References
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-3145
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.20.0-pr-1696-041d-041d438f.zip