### PR TITLE
feat: track timeout errors;

### DIFF
--- a/client-app/core/api/graphql/config/error-handler.ts
+++ b/client-app/core/api/graphql/config/error-handler.ts
@@ -1,13 +1,39 @@
 import { onError } from "@apollo/client/link/error";
+import { useAppInsights } from "vue3-application-insights";
 import { errorHandler } from "@/core/api/common";
 import { GraphQLErrorCode } from "@/core/api/graphql/enums";
 import { hasErrorCode, toServerError } from "@/core/api/graphql/utils";
+import { Logger } from "@/core/utilities";
 import { TabsType, userLockedEvent, passwordExpiredEvent, useBroadcast, graphqlErrorEvent } from "@/shared/broadcast";
 
-export const errorHandlerLink = onError(({ networkError, graphQLErrors }) => {
+export const errorHandlerLink = onError(({ networkError, graphQLErrors, operation }) => {
   const broadcast = useBroadcast();
+  const appInsights = useAppInsights();
 
   errorHandler(toServerError(networkError, graphQLErrors));
+
+  if (networkError instanceof Error && networkError.name === "AbortError" && networkError.message.includes("timeout")) {
+    const errorDetails = {
+      name: "RequestTimeout",
+      message: networkError.message,
+      operation: operation.operationName,
+      variables: operation.variables,
+      timestamp: new Date().toISOString(),
+    };
+
+    Logger.error("Request timeout:", errorDetails);
+
+    if (appInsights) {
+      appInsights.trackException({
+        error: networkError,
+        properties: {
+          operationName: operation.operationName,
+          variables: JSON.stringify(operation.variables),
+          type: "RequestTimeout",
+        },
+      });
+    }
+  }
 
   const userLockedError = hasErrorCode(graphQLErrors, GraphQLErrorCode.UserLocked);
   const passwordExpired = hasErrorCode(graphQLErrors, GraphQLErrorCode.PasswordExpired);


### PR DESCRIPTION
## Description
Add logging to AppInsights of every timeout exception from frontend.
When frontend sends a request to backend and doesn't receive a response during the configured timeout (60 sec), the request is aborted. 
Need to log this case in AppInsights.
## References
### Jira-link:
https://dev.azure.com/omnia-opus/OPUS/_workitems/edit/5783/
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.22.0-pr-1729-1e5f-1e5ff7bf.zip