### PR TITLE
fix: logout user if account was locked

### DIFF
--- a/client-app/shared/account/composables/useUser.ts
+++ b/client-app/shared/account/composables/useUser.ts
@@ -298,11 +298,17 @@ export function useUser() {
     try {
       loading.value = true;
 
-      return await _changePassword({
+      const result = await _changePassword({
         userId: payload.userId,
         oldPassword: payload.oldPassword,
         newPassword: payload.newPassword,
       });
+
+      if (result?.errors?.some((x) => x.code == "AccountLocked")) {
+        void broadcast.emit(userLockedEvent, undefined, TabsType.ALL);
+      }
+
+      return result;
     } catch (e) {
       Logger.error(`${useUser.name}.${resetPassword.name}`, e);
       return { succeeded: false };


### PR DESCRIPTION
## Description
If the user has exceeded the password change attempts limit, he will be logged out and redirected to the account blocked page
## References
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-3647
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.28.0-pr-1855-cd2c-cd2cae59.zip