### PR TITLE
feat(VCST-4672): add data-test-id attributes for variations and configurations buttons

### DIFF
--- a/client-app/shared/catalog/components/product-card.vue
+++ b/client-app/shared/catalog/components/product-card.vue
@@ -74,6 +74,7 @@
 
     <VcProductButton
       v-else-if="product.isConfigurable"
+      data-test-id="product-card-configurations-button"
       :to="getProductRoute(product.id, product.slug)"
       :link-text="$t('pages.catalog.customize_button')"
       :link-to="getProductRoute(product.id, product.slug)"
@@ -86,6 +87,7 @@
     <template v-else-if="product.hasVariations">
       <VcProductButton
         class="product-card__variations-button"
+        data-test-id="product-card-variations-button"
         :link-text="$t('pages.catalog.show_on_a_separate_page')"
         :link-to="link"
         :button-text="$t('pages.catalog.variations_button', [variationsCount])"
@@ -96,6 +98,7 @@
 
       <VcProductButton
         class="product-card__variations-link-button"
+        data-test-id="product-card-variations-link-button"
         :to="link"
         :link-text="$t('pages.catalog.show_on_a_separate_page')"
         :link-to="link"
@@ -116,7 +119,7 @@
     </AddToCartSimple>
 
     <template v-if="viewMode === 'list'" #expanded-content>
-      <div v-show="isExpanded" class="product-card__variants-wrapper">
+      <div v-show="isExpanded" class="product-card__variants-wrapper" data-test-id="product-card-variants-wrapper">
         <div
           v-if="fetchingVariations && (!variations || variations.length === 0)"
           class="product-card__variants-loader"

--- a/client-app/ui-kit/components/molecules/product-button/vc-product-button.vue
+++ b/client-app/ui-kit/components/molecules/product-button/vc-product-button.vue
@@ -15,6 +15,7 @@
         :truncate="truncate"
         :title="title"
         :append-icon="appendIcon"
+        :data-test-id="dataTestId"
         @click="$emit('linkClick', $event)"
       >
         {{ buttonText }}
@@ -67,6 +68,7 @@ interface IProps {
   title?: string;
   size?: "sm" | "md";
   appendIcon?: string;
+  dataTestId?: string;
 }
 
 defineEmits<IEmits>();


### PR DESCRIPTION
Add test selectors for catalog list view: variations button, configurations button, variations link button, and variants wrapper. Forward dataTestId prop through VcProductButton to the inner VcButton for direct clickability in tests.

## Description

## References
### Jira-link:
<!-- Put link to your task in Jira here -->
https://virtocommerce.atlassian.net/browse/VCST-4672
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.43.0-pr-2196-dee1-dee1541f.zip