### PR TITLE
VCST-4664: Add masking to cybersource cvv

### DIFF
--- a/client-app/shared/payment/components/payment-processing-cyber-source.vue
+++ b/client-app/shared/payment/components/payment-processing-cyber-source.vue
@@ -100,6 +100,8 @@ interface IMicroform {
 interface IFieldOptions {
   placeholder?: string;
   maxLength?: number;
+  masking?: { character: string };
+  styles?: Record<string, unknown>;
 }
 
 type FlexConstructorType = {
@@ -321,6 +323,14 @@ function initForm() {
   const securityCode = microform.createField("securityCode", {
     placeholder: "•••",
     maxLength: 4,
+    masking: { character: "\u2022" },
+    styles: {
+      input: {
+        "font-size": "1rem",
+        "-webkit-text-security": "disc",
+        color: "#0a0a0a",
+      },
+    },
   });
   number.load("#cardNumber-container");
   number.on("change", onChange);

--- a/client-app/shared/payment/components/payment-processing-cyber-source.vue
+++ b/client-app/shared/payment/components/payment-processing-cyber-source.vue
@@ -100,6 +100,7 @@ interface IMicroform {
 interface IFieldOptions {
   placeholder?: string;
   maxLength?: number;
+  type?: string;
   masking?: { character: string };
   styles?: Record<string, unknown>;
 }
@@ -323,12 +324,12 @@ function initForm() {
   const securityCode = microform.createField("securityCode", {
     placeholder: "•••",
     maxLength: 4,
+    type: "password",
     masking: { character: "\u2022" },
     styles: {
       input: {
         "font-size": "1rem",
         "-webkit-text-security": "disc",
-        color: "#0a0a0a",
       },
     },
   });


### PR DESCRIPTION
## Description

## References
### Jira-link:
<!-- Put link to your task in Jira here -->
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.43.0-pr-2197-c837-c83727fd.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI/input-configuration change limited to CVV field rendering and local typings; no changes to tokenization or payment authorization logic.
> 
> **Overview**
> Updates the CyberSource payment microform CVV (`securityCode`) field to be masked by configuring it as a password-style input with bullet masking and input-level styling.
> 
> Extends the local `IFieldOptions` TypeScript typing to include the new `type`, `masking`, and `styles` options passed to `microform.createField`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c83727fd04731604cb758d60dcbb9fbf424a3188. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->