### PR TITLE
fix: allow queued mutations to handle different variable types

### DIFF
--- a/client-app/core/api/graphql/config/links/queued-mutations/README.md
+++ b/client-app/core/api/graphql/config/links/queued-mutations/README.md
@@ -84,20 +84,22 @@ If an observer unsubscribes (e.g., component unmounts):
 ### Configuration
 
 ```typescript
+const myConfig: IQueueTargetConfig<MyMutationVariables> = {
+  debounceMs: 1000,
+  mergeQueued: (a, b) => {
+    // Custom merge logic with full type safety for MyMutationVariables
+    return { ...a, ...b };
+  },
+};
+
 createQueuedMutationsLink({
   targets: [
-    {
-      name: "UpdateShortCartItemQuantity",
-      config: {
-        debounceMs: 1000,
-        mergeQueued: (variables1, variables2) => {
-          // Custom merge variables logic
-        }
-      }
-    }
-  ]
+    createQueueTarget("MyMutation", myConfig),
+  ],
 })
 ```
+
+The `createQueueTarget` helper preserves type safety for each target's `mergeQueued` function while allowing heterogeneous targets (different mutation variable types) in the same config array.
 
 ### Target Config
 
@@ -124,7 +126,8 @@ The link exposes `queuedTotal` via `useQueuedMutations()` composable for UI feed
 
 ### Adding New Mutations
 
-1. Add target to `queuedMutationsLink` configuration
+1. Define a typed config: `const myConfig: IQueueTargetConfig<MyMutationVariables> = { ... }`
 2. Implement custom `mergeQueued` function if needed
-3. Define appropriate `debounceMs` for your use case
+3. Add target using `createQueueTarget("MyMutation", myConfig)` to the `queuedMutationsLink` targets array
+4. Define appropriate `debounceMs` for your use case
 

--- a/client-app/core/api/graphql/config/links/queued-mutations/queued-mutations.test.ts
+++ b/client-app/core/api/graphql/config/links/queued-mutations/queued-mutations.test.ts
@@ -1,0 +1,592 @@
+import { Observable, gql } from "@apollo/client/core";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { AbortReason } from "@/core/api/common/enums";
+import { useQueuedMutations } from "@/core/composables/useQueuedMutations";
+import { createQueuedMutationsLink, createQueueTarget, DEFAULT_DEBOUNCE_MS } from "./queued-mutations";
+import type { IQueueTargetConfig } from "./types";
+import type { Operation, NextLink, ApolloLink } from "@apollo/client/core";
+
+const MUTATION_QUERY = gql`
+  mutation TestMutation($input: String!) {
+    testMutation(input: $input) {
+      success
+    }
+  }
+`;
+
+const NON_MUTATION_QUERY = gql`
+  query TestQuery {
+    test {
+      id
+    }
+  }
+`;
+
+function createOperation(operationName: string, variables: Record<string, unknown> = {}): Operation {
+  const _context: Record<string, unknown> = {};
+  return {
+    query: MUTATION_QUERY,
+    operationName,
+    variables,
+    extensions: {},
+    setContext: vi.fn((updater: (prev: Record<string, unknown>) => Record<string, unknown>) => {
+      Object.assign(_context, updater(_context));
+    }),
+    getContext: vi.fn(() => _context),
+  } as unknown as Operation;
+}
+
+function createForward(resolveImmediately = true): NextLink {
+  return vi.fn(
+    () =>
+      new Observable((observer) => {
+        if (resolveImmediately) {
+          setTimeout(() => {
+            observer.next({ data: { success: true } });
+            observer.complete();
+          }, 0);
+        }
+      }),
+  ) as unknown as NextLink;
+}
+
+function subscribe(observable: Observable<unknown>) {
+  const next = vi.fn();
+  const error = vi.fn();
+  const complete = vi.fn();
+  const subscription = observable.subscribe({ next, error, complete });
+  return { next, error, complete, subscription };
+}
+
+function enqueue(link: ApolloLink, forward: NextLink, operationName: string, variables: Record<string, unknown>) {
+  const op = createOperation(operationName, variables);
+  const obs = link.request(op, forward)!;
+  return { operation: op, ...subscribe(obs) };
+}
+
+/** Advance past debounce + resolve the setTimeout(0) inside createForward */
+async function flushAndResolve(debounceMs = DEFAULT_DEBOUNCE_MS) {
+  await vi.advanceTimersByTimeAsync(debounceMs);
+  await vi.advanceTimersByTimeAsync(1);
+}
+
+describe("createQueuedMutationsLink", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    const { setQueuedTotal } = useQueuedMutations();
+    setQueuedTotal(0);
+  });
+
+  afterEach(() => {
+    // #8: defensive reset of global state
+    const { setQueuedTotal } = useQueuedMutations();
+    setQueuedTotal(0);
+    vi.restoreAllMocks();
+  });
+
+  describe("passthrough", () => {
+    it("should forward non-mutation operations unchanged", () => {
+      const link = createQueuedMutationsLink({
+        targets: [{ name: "TestMutation" }],
+      });
+
+      const operation = createOperation("TestQuery");
+      // Override query to be a non-mutation
+      (operation as unknown as { query: unknown }).query = NON_MUTATION_QUERY;
+
+      const forward = vi.fn(() => Observable.of({ data: { test: true } })) as unknown as NextLink;
+      link.request(operation, forward);
+
+      expect(forward).toHaveBeenCalled();
+    });
+
+    it("should forward mutations not in targets list", () => {
+      const link = createQueuedMutationsLink({
+        targets: [{ name: "SomeOtherMutation" }],
+      });
+
+      const forward = vi.fn(() => Observable.of({ data: {} })) as unknown as NextLink;
+      const op = createOperation("UnknownMutation", { a: 1 });
+      link.request(op, forward);
+
+      expect(forward).toHaveBeenCalled();
+    });
+  });
+
+  describe("debouncing", () => {
+    it("should not forward mutation immediately", () => {
+      const link = createQueuedMutationsLink({ targets: [{ name: "TestMutation" }] });
+      const forward = createForward();
+      enqueue(link, forward, "TestMutation", { a: 1 });
+
+      expect(forward).not.toHaveBeenCalled();
+    });
+
+    it("should forward mutation after debounce expires", async () => {
+      const link = createQueuedMutationsLink({ targets: [{ name: "TestMutation" }] });
+      const forward = createForward();
+      enqueue(link, forward, "TestMutation", { a: 1 });
+
+      await vi.advanceTimersByTimeAsync(DEFAULT_DEBOUNCE_MS);
+
+      expect(forward).toHaveBeenCalledTimes(1);
+    });
+
+    it("should use custom debounceMs", async () => {
+      const link = createQueuedMutationsLink({
+        targets: [{ name: "TestMutation", config: { debounceMs: 500 } }],
+      });
+      const forward = createForward();
+      enqueue(link, forward, "TestMutation", { a: 1 });
+
+      await vi.advanceTimersByTimeAsync(400);
+      expect(forward).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(100);
+      expect(forward).toHaveBeenCalledTimes(1);
+    });
+
+    it("should reset debounce timer on new enqueue", async () => {
+      const link = createQueuedMutationsLink({ targets: [{ name: "TestMutation" }] });
+      const forward = createForward();
+
+      enqueue(link, forward, "TestMutation", { a: 1 });
+      await vi.advanceTimersByTimeAsync(800);
+      expect(forward).not.toHaveBeenCalled();
+
+      enqueue(link, forward, "TestMutation", { a: 2 });
+      await vi.advanceTimersByTimeAsync(800);
+      expect(forward).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(200);
+      expect(forward).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("merging", () => {
+    it("should merge variables with default strategy (spread)", async () => {
+      const link = createQueuedMutationsLink({ targets: [{ name: "TestMutation" }] });
+      const forward = createForward();
+
+      enqueue(link, forward, "TestMutation", { a: 1, b: 2 });
+      enqueue(link, forward, "TestMutation", { b: 3, c: 4 });
+
+      await vi.advanceTimersByTimeAsync(DEFAULT_DEBOUNCE_MS);
+
+      expect(forward).toHaveBeenCalledTimes(1);
+      expect((forward as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0].variables).toEqual({ a: 1, b: 3, c: 4 });
+    });
+
+    it("should accumulate correctly across 3+ calls with overlapping keys", async () => {
+      const link = createQueuedMutationsLink({ targets: [{ name: "TestMutation" }] });
+      const forward = createForward();
+
+      enqueue(link, forward, "TestMutation", { a: 1 });
+      enqueue(link, forward, "TestMutation", { a: 2 });
+      enqueue(link, forward, "TestMutation", { a: 3 });
+
+      await vi.advanceTimersByTimeAsync(DEFAULT_DEBOUNCE_MS);
+
+      expect((forward as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0].variables).toEqual({ a: 3 });
+    });
+
+    it("should use custom mergeQueued function", async () => {
+      type Vars = { items: string[] };
+      const config: IQueueTargetConfig<Vars> = {
+        mergeQueued: (a, b) => ({ items: [...a.items, ...b.items] }),
+      };
+
+      const link = createQueuedMutationsLink({
+        targets: [createQueueTarget("TestMutation", config)],
+      });
+      const forward = createForward();
+
+      enqueue(link, forward, "TestMutation", { items: ["a"] });
+      enqueue(link, forward, "TestMutation", { items: ["b", "c"] });
+
+      await vi.advanceTimersByTimeAsync(DEFAULT_DEBOUNCE_MS);
+
+      expect((forward as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0].variables).toEqual({
+        items: ["a", "b", "c"],
+      });
+    });
+
+    it("should merge many calls into one request", async () => {
+      const link = createQueuedMutationsLink({ targets: [{ name: "TestMutation" }] });
+      const forward = createForward();
+
+      for (let i = 0; i < 5; i++) {
+        enqueue(link, forward, "TestMutation", { [`key${i}`]: i });
+      }
+
+      await vi.advanceTimersByTimeAsync(DEFAULT_DEBOUNCE_MS);
+
+      expect(forward).toHaveBeenCalledTimes(1);
+      expect((forward as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0].variables).toEqual({
+        key0: 0,
+        key1: 1,
+        key2: 2,
+        key3: 3,
+        key4: 4,
+      });
+    });
+  });
+
+  describe("observer notification", () => {
+    it("should notify all queued observers on success", async () => {
+      const link = createQueuedMutationsLink({ targets: [{ name: "TestMutation" }] });
+      const forward = createForward();
+
+      const sub1 = enqueue(link, forward, "TestMutation", { a: 1 });
+      const sub2 = enqueue(link, forward, "TestMutation", { a: 2 });
+
+      await flushAndResolve();
+
+      expect(sub1.next).toHaveBeenCalledWith({ data: { success: true } });
+      expect(sub1.complete).toHaveBeenCalled();
+      expect(sub2.next).toHaveBeenCalledWith({ data: { success: true } });
+      expect(sub2.complete).toHaveBeenCalled();
+    });
+
+    it("should notify all queued observers on error", async () => {
+      const networkError = new Error("Network failure");
+      const link = createQueuedMutationsLink({ targets: [{ name: "TestMutation" }] });
+      const forward = vi.fn(
+        () =>
+          new Observable((observer) => {
+            setTimeout(() => observer.error(networkError), 0);
+          }),
+      ) as unknown as NextLink;
+
+      const sub1 = enqueue(link, forward, "TestMutation", { a: 1 });
+      const sub2 = enqueue(link, forward, "TestMutation", { a: 2 });
+
+      await flushAndResolve();
+
+      expect(sub1.error).toHaveBeenCalledWith(networkError);
+      expect(sub2.error).toHaveBeenCalledWith(networkError);
+    });
+
+    // #12: complete is NOT called on error (Observable contract)
+    it("should not call complete on error path", async () => {
+      const link = createQueuedMutationsLink({ targets: [{ name: "TestMutation" }] });
+      const forward = vi.fn(
+        () =>
+          new Observable((observer) => {
+            setTimeout(() => observer.error(new Error("fail")), 0);
+          }),
+      ) as unknown as NextLink;
+
+      const sub = enqueue(link, forward, "TestMutation", { a: 1 });
+
+      await flushAndResolve();
+
+      expect(sub.error).toHaveBeenCalled();
+      expect(sub.complete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("in-flight behavior", () => {
+    it("should queue new mutations while one is in flight and flush after it completes", async () => {
+      const link = createQueuedMutationsLink({ targets: [{ name: "TestMutation" }] });
+
+      let resolveFirst!: () => void;
+      const forward = vi.fn(
+        () =>
+          new Observable((observer) => {
+            resolveFirst = () => {
+              observer.next({ data: {} });
+              observer.complete();
+            };
+          }),
+      ) as unknown as NextLink;
+
+      // First batch
+      enqueue(link, forward, "TestMutation", { batch: 1 });
+      await vi.advanceTimersByTimeAsync(DEFAULT_DEBOUNCE_MS);
+      expect(forward).toHaveBeenCalledTimes(1);
+
+      // Enqueue while in flight
+      enqueue(link, forward, "TestMutation", { batch: 2 });
+
+      // Resolve first request — triggers scheduleNextFlush for queued batch
+      resolveFirst();
+
+      await vi.advanceTimersByTimeAsync(DEFAULT_DEBOUNCE_MS);
+      expect(forward).toHaveBeenCalledTimes(2);
+      expect((forward as unknown as ReturnType<typeof vi.fn>).mock.calls[1][0].variables).toEqual({ batch: 2 });
+    });
+
+    it("should not flush while request is in flight", async () => {
+      const link = createQueuedMutationsLink({ targets: [{ name: "TestMutation" }] });
+      const forward = vi.fn(() => new Observable(() => {})) as unknown as NextLink; // never resolves
+
+      enqueue(link, forward, "TestMutation", { a: 1 });
+      await vi.advanceTimersByTimeAsync(DEFAULT_DEBOUNCE_MS);
+      expect(forward).toHaveBeenCalledTimes(1);
+
+      // Enqueue while in flight
+      enqueue(link, forward, "TestMutation", { a: 2 });
+      await vi.advanceTimersByTimeAsync(DEFAULT_DEBOUNCE_MS);
+
+      // Should not send second request while first is in flight
+      expect(forward).toHaveBeenCalledTimes(1);
+    });
+
+    // #5: queue works again after an error flush
+    it("should continue processing after error", async () => {
+      const link = createQueuedMutationsLink({ targets: [{ name: "TestMutation" }] });
+
+      let callCount = 0;
+      const forward = vi.fn(
+        () =>
+          new Observable((observer) => {
+            callCount++;
+            setTimeout(() => {
+              if (callCount === 1) {
+                observer.error(new Error("first fails"));
+              } else {
+                observer.next({ data: { recovered: true } });
+                observer.complete();
+              }
+            }, 0);
+          }),
+      ) as unknown as NextLink;
+
+      // First batch — will error
+      const sub1 = enqueue(link, forward, "TestMutation", { a: 1 });
+      await flushAndResolve();
+      expect(sub1.error).toHaveBeenCalled();
+
+      // Second batch after error — should work
+      const sub2 = enqueue(link, forward, "TestMutation", { a: 2 });
+      await flushAndResolve();
+      expect(sub2.next).toHaveBeenCalledWith({ data: { recovered: true } });
+      expect(sub2.complete).toHaveBeenCalled();
+    });
+  });
+
+  describe("cleanup & cancellation", () => {
+    it("should clear timer on unsubscribe", async () => {
+      const link = createQueuedMutationsLink({ targets: [{ name: "TestMutation" }] });
+      const forward = createForward();
+
+      const { subscription } = enqueue(link, forward, "TestMutation", { a: 1 });
+      subscription.unsubscribe();
+
+      await vi.advanceTimersByTimeAsync(DEFAULT_DEBOUNCE_MS);
+      expect(forward).not.toHaveBeenCalled();
+    });
+
+    // #3: assert AbortReason.Explicit
+    it("should abort in-flight request with AbortReason.Explicit on unsubscribe", async () => {
+      const abortSpy = vi.spyOn(AbortController.prototype, "abort");
+
+      const link = createQueuedMutationsLink({ targets: [{ name: "TestMutation" }] });
+      const forward = vi.fn(() => new Observable(() => {})) as unknown as NextLink; // never resolves
+
+      const { subscription } = enqueue(link, forward, "TestMutation", { a: 1 });
+
+      await vi.advanceTimersByTimeAsync(DEFAULT_DEBOUNCE_MS);
+      expect(forward).toHaveBeenCalled();
+
+      subscription.unsubscribe();
+      expect(abortSpy).toHaveBeenCalledWith(AbortReason.Explicit);
+    });
+
+    // #6: abort signal is wired into operation context
+    it("should inject abort signal into operation fetchOptions via setContext", async () => {
+      const link = createQueuedMutationsLink({ targets: [{ name: "TestMutation" }] });
+      const forward = vi.fn(() => new Observable(() => {})) as unknown as NextLink; // never resolves
+
+      const { operation } = enqueue(link, forward, "TestMutation", { a: 1 });
+
+      await vi.advanceTimersByTimeAsync(DEFAULT_DEBOUNCE_MS);
+
+      expect(operation.setContext).toHaveBeenCalled();
+      const context = operation.getContext();
+      expect(context.fetchOptions).toBeDefined();
+      expect(context.fetchOptions.signal).toBeInstanceOf(AbortSignal);
+    });
+
+    // #11: unsubscribe one of many observers
+    it("should clear timer for entire operation when any observer unsubscribes", async () => {
+      const link = createQueuedMutationsLink({ targets: [{ name: "TestMutation" }] });
+      const forward = createForward();
+
+      enqueue(link, forward, "TestMutation", { a: 1 });
+      const { subscription: sub2 } = enqueue(link, forward, "TestMutation", { a: 2 });
+
+      // Unsubscribe the second observer — clears the timer for the whole operation
+      sub2.unsubscribe();
+
+      await vi.advanceTimersByTimeAsync(DEFAULT_DEBOUNCE_MS);
+      // Timer was cleared, so flush never fires
+      expect(forward).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("queuedTotal integration", () => {
+    it("should increment queuedTotal when enqueuing", () => {
+      const link = createQueuedMutationsLink({ targets: [{ name: "TestMutation" }] });
+      const forward = createForward();
+      const { queuedTotal } = useQueuedMutations();
+
+      expect(queuedTotal.value).toBe(0);
+
+      enqueue(link, forward, "TestMutation", { a: 1 });
+      expect(queuedTotal.value).toBe(1);
+
+      enqueue(link, forward, "TestMutation", { a: 2 });
+      expect(queuedTotal.value).toBe(2);
+    });
+
+    it("should reset queuedTotal to 0 after flush completes", async () => {
+      const link = createQueuedMutationsLink({ targets: [{ name: "TestMutation" }] });
+      const forward = createForward();
+      const { queuedTotal } = useQueuedMutations();
+
+      enqueue(link, forward, "TestMutation", { a: 1 });
+      enqueue(link, forward, "TestMutation", { a: 2 });
+      expect(queuedTotal.value).toBe(2);
+
+      await vi.advanceTimersByTimeAsync(DEFAULT_DEBOUNCE_MS);
+      expect(queuedTotal.value).toBe(0);
+    });
+
+    it("should reflect hasQueuedMutations correctly", async () => {
+      const link = createQueuedMutationsLink({ targets: [{ name: "TestMutation" }] });
+      const forward = createForward();
+      const { hasQueuedMutations } = useQueuedMutations();
+
+      expect(hasQueuedMutations.value).toBe(false);
+
+      enqueue(link, forward, "TestMutation", { a: 1 });
+      expect(hasQueuedMutations.value).toBe(true);
+
+      await vi.advanceTimersByTimeAsync(DEFAULT_DEBOUNCE_MS);
+      expect(hasQueuedMutations.value).toBe(false);
+    });
+
+    // #7: queuedTotal across multiple operation names
+    it("should sum queuedTotal across different operation names", () => {
+      const link = createQueuedMutationsLink({
+        targets: [{ name: "MutationA" }, { name: "MutationB" }],
+      });
+      const forward = createForward();
+      const { queuedTotal } = useQueuedMutations();
+
+      enqueue(link, forward, "MutationA", { a: 1 });
+      expect(queuedTotal.value).toBe(1);
+
+      enqueue(link, forward, "MutationB", { b: 1 });
+      expect(queuedTotal.value).toBe(2);
+
+      enqueue(link, forward, "MutationA", { a: 2 });
+      expect(queuedTotal.value).toBe(3);
+    });
+  });
+
+  describe("independent operation queues", () => {
+    it("should maintain separate queues per operation name", async () => {
+      const link = createQueuedMutationsLink({
+        targets: [
+          { name: "MutationA", config: { debounceMs: 500 } },
+          { name: "MutationB", config: { debounceMs: 1500 } },
+        ],
+      });
+      const forward = createForward();
+
+      enqueue(link, forward, "MutationA", { type: "A" });
+      enqueue(link, forward, "MutationB", { type: "B" });
+
+      await vi.advanceTimersByTimeAsync(500);
+      expect(forward).toHaveBeenCalledTimes(1);
+      expect((forward as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0].variables).toEqual({ type: "A" });
+
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(forward).toHaveBeenCalledTimes(2);
+      expect((forward as unknown as ReturnType<typeof vi.fn>).mock.calls[1][0].variables).toEqual({ type: "B" });
+    });
+
+    it("should merge independently per operation name", async () => {
+      const link = createQueuedMutationsLink({
+        targets: [{ name: "MutationA" }, { name: "MutationB" }],
+      });
+      const forward = createForward();
+
+      enqueue(link, forward, "MutationA", { a: 1 });
+      enqueue(link, forward, "MutationA", { a: 2 });
+      enqueue(link, forward, "MutationB", { b: 10 });
+      enqueue(link, forward, "MutationB", { b: 20 });
+
+      await vi.advanceTimersByTimeAsync(DEFAULT_DEBOUNCE_MS);
+
+      expect(forward).toHaveBeenCalledTimes(2);
+      const fwd = forward as unknown as ReturnType<typeof vi.fn>;
+      const vars = fwd.mock.calls.map((c: unknown[]) => (c[0] as { variables: unknown }).variables);
+      expect(vars).toContainEqual({ a: 2 });
+      expect(vars).toContainEqual({ b: 20 });
+    });
+  });
+
+  // #2: use createQueueTarget helper in tests
+  describe("createQueueTarget", () => {
+    it("should produce a valid target accepted by createQueuedMutationsLink", async () => {
+      type Vars = { count: number };
+      const config: IQueueTargetConfig<Vars> = {
+        debounceMs: 200,
+        mergeQueued: (a, b) => ({ count: a.count + b.count }),
+      };
+
+      const target = createQueueTarget("CountMutation", config);
+      expect(target.name).toBe("CountMutation");
+      expect(target.config).toBeDefined();
+
+      // Verify it works end-to-end through the link
+      const link = createQueuedMutationsLink({ targets: [target] });
+      const forward = createForward();
+
+      enqueue(link, forward, "CountMutation", { count: 1 });
+      enqueue(link, forward, "CountMutation", { count: 2 });
+
+      await vi.advanceTimersByTimeAsync(200);
+
+      expect(forward).toHaveBeenCalledTimes(1);
+      expect((forward as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0].variables).toEqual({ count: 3 });
+    });
+  });
+
+  describe("heterogeneous targets", () => {
+    it("should support targets with different variable types and custom merge per target", async () => {
+      type VarsA = { items: string[] };
+      type VarsB = { sections: number[] };
+
+      const link = createQueuedMutationsLink({
+        targets: [
+          createQueueTarget<VarsA>("MutationA", {
+            mergeQueued: (a, b) => ({ items: [...a.items, ...b.items] }),
+          }),
+          createQueueTarget<VarsB>("MutationB", {
+            mergeQueued: (a, b) => ({ sections: [...a.sections, ...b.sections] }),
+          }),
+        ],
+      });
+      const forward = createForward();
+
+      enqueue(link, forward, "MutationA", { items: ["x"] });
+      enqueue(link, forward, "MutationA", { items: ["y"] });
+      enqueue(link, forward, "MutationB", { sections: [1] });
+      enqueue(link, forward, "MutationB", { sections: [2] });
+
+      // #13: consistent flushAndResolve usage
+      await flushAndResolve();
+
+      expect(forward).toHaveBeenCalledTimes(2);
+      const fwd = forward as unknown as ReturnType<typeof vi.fn>;
+      const vars = fwd.mock.calls.map((c: unknown[]) => (c[0] as { variables: unknown }).variables);
+      expect(vars).toContainEqual({ items: ["x", "y"] });
+      expect(vars).toContainEqual({ sections: [1, 2] });
+    });
+  });
+});

--- a/client-app/core/api/graphql/config/links/queued-mutations/queued-mutations.ts
+++ b/client-app/core/api/graphql/config/links/queued-mutations/queued-mutations.ts
@@ -6,7 +6,7 @@ import type { IQueueConfig, IQueueTargetConfig, IQueueTarget, IOperationState, I
 import type { UpdateShortCartItemQuantityMutationVariables } from "@/core/api/graphql/types";
 import type { DefaultContext } from "@apollo/client/core";
 
-const DEFAULT_DEBOUNCE_MS = 1000;
+export const DEFAULT_DEBOUNCE_MS = 1000;
 
 /**
  * Creates a queued mutations link.
@@ -206,7 +206,7 @@ const updateShortCartItemQuantityConfig: IQueueTargetConfig<UpdateShortCartItemQ
  * This preserves type safety when defining each target while allowing
  * heterogeneous targets in the config array.
  */
-function createQueueTarget<TVars extends Record<string, unknown>>(
+export function createQueueTarget<TVars extends Record<string, unknown>>(
   name: string,
   config: IQueueTargetConfig<TVars>,
 ): IQueueTarget {

--- a/client-app/core/api/graphql/config/links/queued-mutations/queued-mutations.ts
+++ b/client-app/core/api/graphql/config/links/queued-mutations/queued-mutations.ts
@@ -2,7 +2,7 @@ import { ApolloLink, Observable } from "@apollo/client/core";
 import { AbortReason } from "@/core/api/common/enums";
 import { useQueuedMutations } from "@/core/composables/useQueuedMutations";
 import { isMutation, defaultMergeVariables } from "../utils";
-import type { IQueueConfig, IQueueTargetConfig, IOperationState, IObserver } from "./types";
+import type { IQueueConfig, IQueueTargetConfig, IQueueTarget, IOperationState, IObserver } from "./types";
 import type { UpdateShortCartItemQuantityMutationVariables } from "@/core/api/graphql/types";
 import type { DefaultContext } from "@apollo/client/core";
 
@@ -14,12 +14,11 @@ const DEFAULT_DEBOUNCE_MS = 1000;
  * Further actions happening while network request is in flight + debounce time are queued and will be merged with the next network request.
  * @param config @link{IQueueConfig} - The configuration for the queued mutations link.
  */
-export function createQueuedMutationsLink<TVars extends Record<string, unknown>>(
-  config: IQueueConfig<TVars>,
-): ApolloLink {
+export function createQueuedMutationsLink(config: IQueueConfig): ApolloLink {
+  type TVarsType = Record<string, unknown>;
   const targets = new Set<string>(Array.from(config.targets.map((t) => t.name)));
 
-  const targetConfigMap = new Map<string, Required<IQueueTargetConfig<TVars>>>(
+  const targetConfigMap = new Map<string, Required<IQueueTargetConfig<TVarsType>>>(
     config.targets.map((target) => [
       target.name,
       {
@@ -29,17 +28,17 @@ export function createQueuedMutationsLink<TVars extends Record<string, unknown>>
     ]),
   );
 
-  const stateByOperation = new Map<string, IOperationState<TVars>>();
+  const stateByOperation = new Map<string, IOperationState<TVarsType>>();
   const { setQueuedTotal } = useQueuedMutations();
 
-  function getState(opName: string): IOperationState<TVars> {
+  function getState(opName: string): IOperationState<TVarsType> {
     const state = stateByOperation.get(opName);
 
     if (state) {
       return state;
     }
 
-    const newState: IOperationState<TVars> = {
+    const newState: IOperationState<TVarsType> = {
       inFlight: false,
       timer: null,
       mergedVariables: null,
@@ -89,7 +88,7 @@ export function createQueuedMutationsLink<TVars extends Record<string, unknown>>
     }, debounceMs);
   }
 
-  function enqueue(opName: string, variables: TVars, observer: IObserver): void {
+  function enqueue(opName: string, variables: TVarsType, observer: IObserver): void {
     const state = getState(opName);
     const { mergeQueued } = getTargetConfig(opName);
 
@@ -168,7 +167,7 @@ export function createQueuedMutationsLink<TVars extends Record<string, unknown>>
         state.forward = forward;
       }
 
-      enqueue(opName, operation.variables as TVars, observer as IObserver);
+      enqueue(opName, operation.variables as TVarsType, observer as IObserver);
 
       // Cleanup function
       return () => {
@@ -202,11 +201,18 @@ const updateShortCartItemQuantityConfig: IQueueTargetConfig<UpdateShortCartItemQ
   },
 };
 
+/**
+ * Helper function to create a properly typed queue target.
+ * This preserves type safety when defining each target while allowing
+ * heterogeneous targets in the config array.
+ */
+function createQueueTarget<TVars extends Record<string, unknown>>(
+  name: string,
+  config: IQueueTargetConfig<TVars>,
+): IQueueTarget {
+  return { name, config: config as IQueueTargetConfig };
+}
+
 export const queuedMutationsLink = createQueuedMutationsLink({
-  targets: [
-    {
-      name: "UpdateShortCartItemQuantity",
-      config: updateShortCartItemQuantityConfig,
-    },
-  ],
+  targets: [createQueueTarget("UpdateShortCartItemQuantity", updateShortCartItemQuantityConfig)],
 });

--- a/client-app/core/api/graphql/config/links/queued-mutations/types.ts
+++ b/client-app/core/api/graphql/config/links/queued-mutations/types.ts
@@ -15,8 +15,13 @@ export interface IQueueTargetConfig<TVars extends Record<string, unknown> = Reco
   mergeQueued?: MergeQueuedFnType<TVars>;
 }
 
-export interface IQueueConfig<TVars extends Record<string, unknown> = Record<string, unknown>> {
-  targets: Array<{ name: string; config?: IQueueTargetConfig<TVars> }>;
+export interface IQueueTarget<TVars extends Record<string, unknown> = Record<string, unknown>> {
+  name: string;
+  config?: IQueueTargetConfig<TVars>;
+}
+
+export interface IQueueConfig {
+  targets: IQueueTarget<Record<string, unknown>>[];
 }
 
 export interface IObserver {


### PR DESCRIPTION
## Description

The queued mutations link was meant to batch any mutation — but its types had a bug.      
                                                                                        
  The whole config was generic with a single <TVars>, meaning all targets had to share the  
  same variable type:                                                                   

```ts                                                                                            
  // Before: TVars can't be two different types at once                                 
  createQueuedMutationsLink<???>({             
    targets: [
      { name: "UpdateCartQuantity", config: quantityConfig },     // { items: [...] }
      { name: "UpdateConfiguration", config: configConfig },      // {
  configurationSections: [...] } ← type error
    ]
  })
  ```

  Nobody noticed because there was only one target. The moment you add a second mutation
  with a different shape — it breaks.

  The fix: make the config non-generic and add a createQueueTarget helper that type-checks
  each target independently:

```ts
  // After: each target keeps its own type safety
  createQueuedMutationsLink({
    targets: [
      createQueueTarget("UpdateCartQuantity", quantityConfig),      // type-safe
      createQueueTarget("UpdateConfiguration", configConfig),       // type-safe, different
  shape — no conflict
    ]
  })
```

  Each mergeQueued still gets full autocomplete for its specific variables. The config just
  stopped forcing them all into one type.

## References
### Jira-link:
<!-- Put link to your task in Jira here -->
https://virtocommerce.atlassian.net/browse/VCST-4744
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.43.0-pr-2207-614e-614e74ca.zip