### PR TITLE
VCST-4746: Migrate deploy check to vc-build

### DIFF
--- a/.github/workflows/deploy-cloud.yml
+++ b/.github/workflows/deploy-cloud.yml
@@ -122,7 +122,7 @@ jobs:
       timeout-minutes: 5
       run: |
         dotnet tool install --global VirtoCommerce.GlobalTool || true
-        vc-build CloudEnvStatus -CloudUrl ${{ env.CLOUD_URL }} -CloudToken ${{ env.VIRTOCLOUD_KEY }} -EnvironmentName ${{ steps.deployConfig.outputs.deployAppName }} -HealthStatus Healthy -SyncStatus Synced
+        vc-build CloudEnvStatus -CloudUrl $CLOUD_URL -CloudToken $VIRTOCLOUD_KEY -EnvironmentName ${{ steps.deployConfig.outputs.deployAppName }} -HealthStatus Healthy -SyncStatus Synced
       shell: bash
 
     - name: DEPLOY_STATE::successful

--- a/.github/workflows/deploy-cloud.yml
+++ b/.github/workflows/deploy-cloud.yml
@@ -3,10 +3,6 @@ name: VC cloud deployment
 on:
   workflow_call:
     inputs:
-      argoServer:
-        required: false
-        default: 'argo.virtocommerce.cloud'
-        type: string
       cmPath:
         description: 'JSON configuration map file path (with quotes)'
         required: false
@@ -34,12 +30,13 @@ on:
         required: false
         default: false
         type: boolean
+      cloudUrl:
+        description: 'Cloud URL for checking status'
+        default: 'https://portal.virtocommerce.cloud'
+        required: false
+        type: string
   workflow_dispatch:
     inputs:
-      argoServer:
-        required: false
-        default: 'argo.virtocommerce.cloud'
-        type: string
       cmPath:
         description: 'JSON configuration map file path (with quotes)'
         required: false
@@ -72,7 +69,6 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     env:
-      ARGO_SERVER: ${{ inputs.argoServer }}
       CLIENT_ID: ${{secrets.CLIENT_ID}}
       CLIENT_SECRET: ${{secrets.CLIENT_SECRET}}
       CLOUD_INSTANCE_BASE_URL: ${{secrets.CLOUD_INSTANCE_BASE_URL}}

--- a/.github/workflows/deploy-cloud.yml
+++ b/.github/workflows/deploy-cloud.yml
@@ -91,82 +91,82 @@ jobs:
         envName: ${{ inputs.environmentId }}
         deployConfigPath: .deployment/theme/cloudDeploy.json
 
-    # - name: Start deployment
-    #   uses: bobheadxi/deployments@main
-    #   id: deployment
-    #   with:
-    #     step: start
-    #     token: ${{ env.GITHUB_TOKEN }}
-    #     env: ${{ steps.deployConfig.outputs.environmentName }}
-    #     override: true
+    - name: Start deployment
+      uses: bobheadxi/deployments@main
+      id: deployment
+      with:
+        step: start
+        token: ${{ env.GITHUB_TOKEN }}
+        env: ${{ steps.deployConfig.outputs.environmentName }}
+        override: true
 
-    # - name: Deploy to ${{ steps.deployConfig.outputs.environmentName }}
-    #   uses: VirtoCommerce/vc-github-actions/create-deploy-pr@master
-    #   with:
-    #     githubToken: ${{ env.GITHUB_TOKEN }}
-    #     deployRepo: ${{ steps.deployConfig.outputs.deployRepo }}
-    #     deployBranch: ${{ steps.deployConfig.outputs.deployBranch }}
-    #     cmPath: ${{ inputs.cmPath || steps.deployConfig.outputs.cmPath }}
-    #     artifactKey: '"${{ inputs.artifactKey || steps.deployConfig.outputs.artifactKey }}"'
-    #     artifactUrl: '"${{ inputs.artifactUrl }}"'
-    #     taskNumber: ${{ inputs.jiraKeys }}
-    #     forceCommit: ${{ inputs.forceCommit }}
+    - name: Deploy to ${{ steps.deployConfig.outputs.environmentName }}
+      uses: VirtoCommerce/vc-github-actions/create-deploy-pr@master
+      with:
+        githubToken: ${{ env.GITHUB_TOKEN }}
+        deployRepo: ${{ steps.deployConfig.outputs.deployRepo }}
+        deployBranch: ${{ steps.deployConfig.outputs.deployBranch }}
+        cmPath: ${{ inputs.cmPath || steps.deployConfig.outputs.cmPath }}
+        artifactKey: '"${{ inputs.artifactKey || steps.deployConfig.outputs.artifactKey }}"'
+        artifactUrl: '"${{ inputs.artifactUrl }}"'
+        taskNumber: ${{ inputs.jiraKeys }}
+        forceCommit: ${{ inputs.forceCommit }}
 
-    # - name: Sleep for ${{ env.SLEEP_TIME }}
-    #   if: ${{ inputs.forceCommit }}
-    #   run: sleep ${{ env.SLEEP_TIME }}
-    #   shell: bash
+    - name: Sleep for ${{ env.SLEEP_TIME }}
+      if: ${{ inputs.forceCommit }}
+      run: sleep ${{ env.SLEEP_TIME }}
+      shell: bash
 
     - name: Check deployment status
-      # if: ${{ inputs.forceCommit }}
+      if: ${{ inputs.forceCommit }}
       timeout-minutes: 5
       run: |
         dotnet tool install --global VirtoCommerce.GlobalTool || true
         vc-build CloudEnvStatus -CloudUrl ${{ env.CLOUD_URL }} -CloudToken ${{ env.VIRTOCLOUD_KEY }} -EnvironmentName ${{ steps.deployConfig.outputs.deployAppName }} -HealthStatus Healthy -SyncStatus Synced
       shell: bash
 
-    # - name: DEPLOY_STATE::successful
-    #   if: success()
-    #   run: echo "DEPLOY_STATE=successful" >> $GITHUB_ENV
+    - name: DEPLOY_STATE::successful
+      if: success()
+      run: echo "DEPLOY_STATE=successful" >> $GITHUB_ENV
 
-    # - name: DEPLOY_STATE::failed
-    #   if: failure()
-    #   run: echo "DEPLOY_STATE=failed"  >> $GITHUB_ENV
+    - name: DEPLOY_STATE::failed
+      if: failure()
+      run: echo "DEPLOY_STATE=failed"  >> $GITHUB_ENV
 
-    # - name: Update GitHub deployment status
-    #   uses: bobheadxi/deployments@main
-    #   if: always()
-    #   with:
-    #     step: finish
-    #     token: ${{ env.GITHUB_TOKEN }}
-    #     status: ${{ job.status }}
-    #     env: ${{ steps.deployment.outputs.env }}
-    #     deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+    - name: Update GitHub deployment status
+      uses: bobheadxi/deployments@main
+      if: always()
+      with:
+        step: finish
+        token: ${{ env.GITHUB_TOKEN }}
+        status: ${{ job.status }}
+        env: ${{ steps.deployment.outputs.env }}
+        deployment_id: ${{ steps.deployment.outputs.deployment_id }}
 
-    # - name: Push Deployment Info to Jira
-    #   if: ${{ env.CLOUD_INSTANCE_BASE_URL != 0 && env.CLIENT_ID != 0 && env.CLIENT_SECRET != 0 && inputs.jiraKeys != '' && always() }}
-    #   id: push_deployment_info_to_jira
-    #   uses: VirtoCommerce/jira-upload-deployment-info@master
-    #   env:
-    #     CLOUD_INSTANCE_BASE_URL: ${{secrets.CLOUD_INSTANCE_BASE_URL}}
-    #     CLIENT_ID: ${{secrets.CLIENT_ID}}
-    #     CLIENT_SECRET: ${{secrets.CLIENT_SECRET}}
-    #   with:
-    #     cloud-instance-base-url: ${{ secrets.CLOUD_INSTANCE_BASE_URL }}
-    #     client-id: ${{ secrets.CLIENT_ID }}
-    #     client-secret: ${{ secrets.CLIENT_SECRET }}
-    #     deployment-sequence-number: ${{ github.run_id }}
-    #     update-sequence-number: ${{ github.run_id }}
-    #     issue-keys: ${{ inputs.jiraKeys }}
-    #     display-name: ${{ steps.deployConfig.outputs.deployAppName }}
-    #     url: ${{ steps.deployConfig.outputs.environmentUrl }}
-    #     label: ${{ steps.deployConfig.outputs.environmentName }}
-    #     description: 'Deployment to the ${{ steps.deployConfig.outputs.environmentName }} environment'
-    #     last-updated: '${{github.event.head_commit.timestamp}}'
-    #     state: '${{ env.DEPLOY_STATE }}'
-    #     pipeline-id: '${{ github.repository }} ${{ github.workflow }}'
-    #     pipeline-display-name: 'Workflow: ${{ github.workflow }} (#${{ github.run_number }})'
-    #     pipeline-url: '${{github.event.repository.html_url}}/actions/runs/${{github.run_id}}'
-    #     environment-id: ${{ steps.deployConfig.outputs.environmentId }}
-    #     environment-display-name: ${{ steps.deployConfig.outputs.environmentName }}
-    #     environment-type: ${{ steps.deployConfig.outputs.environmentType }}
+    - name: Push Deployment Info to Jira
+      if: ${{ env.CLOUD_INSTANCE_BASE_URL != 0 && env.CLIENT_ID != 0 && env.CLIENT_SECRET != 0 && inputs.jiraKeys != '' && always() }}
+      id: push_deployment_info_to_jira
+      uses: VirtoCommerce/jira-upload-deployment-info@master
+      env:
+        CLOUD_INSTANCE_BASE_URL: ${{secrets.CLOUD_INSTANCE_BASE_URL}}
+        CLIENT_ID: ${{secrets.CLIENT_ID}}
+        CLIENT_SECRET: ${{secrets.CLIENT_SECRET}}
+      with:
+        cloud-instance-base-url: ${{ secrets.CLOUD_INSTANCE_BASE_URL }}
+        client-id: ${{ secrets.CLIENT_ID }}
+        client-secret: ${{ secrets.CLIENT_SECRET }}
+        deployment-sequence-number: ${{ github.run_id }}
+        update-sequence-number: ${{ github.run_id }}
+        issue-keys: ${{ inputs.jiraKeys }}
+        display-name: ${{ steps.deployConfig.outputs.deployAppName }}
+        url: ${{ steps.deployConfig.outputs.environmentUrl }}
+        label: ${{ steps.deployConfig.outputs.environmentName }}
+        description: 'Deployment to the ${{ steps.deployConfig.outputs.environmentName }} environment'
+        last-updated: '${{github.event.head_commit.timestamp}}'
+        state: '${{ env.DEPLOY_STATE }}'
+        pipeline-id: '${{ github.repository }} ${{ github.workflow }}'
+        pipeline-display-name: 'Workflow: ${{ github.workflow }} (#${{ github.run_number }})'
+        pipeline-url: '${{github.event.repository.html_url}}/actions/runs/${{github.run_id}}'
+        environment-id: ${{ steps.deployConfig.outputs.environmentId }}
+        environment-display-name: ${{ steps.deployConfig.outputs.environmentName }}
+        environment-type: ${{ steps.deployConfig.outputs.environmentType }}

--- a/.github/workflows/deploy-cloud.yml
+++ b/.github/workflows/deploy-cloud.yml
@@ -118,7 +118,7 @@ jobs:
     #   shell: bash
 
     - name: Check deployment status
-      if: ${{ inputs.forceCommit }}
+      # if: ${{ inputs.forceCommit }}
       timeout-minutes: 5
       run: |
         dotnet tool install --global VirtoCommerce.GlobalTool || true

--- a/.github/workflows/deploy-cloud.yml
+++ b/.github/workflows/deploy-cloud.yml
@@ -62,6 +62,11 @@ on:
         required: false
         default: ''
         type: string
+      cloudUrl:
+        description: 'Cloud URL for checking status'
+        default: 'https://portal.virtocommerce.cloud'
+        required: false
+        type: string
 
 jobs:
   deploy:
@@ -71,9 +76,11 @@ jobs:
       CLIENT_ID: ${{secrets.CLIENT_ID}}
       CLIENT_SECRET: ${{secrets.CLIENT_SECRET}}
       CLOUD_INSTANCE_BASE_URL: ${{secrets.CLOUD_INSTANCE_BASE_URL}}
+      CLOUD_URL: ${{ inputs.cloudUrl }}
       DEPLOY_STATE: ''
       GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
       SLEEP_TIME: '3m'
+      VIRTOCLOUD_KEY: ${{ secrets.VIRTOCLOUD_KEY_VCPT_VCST }}
 
     steps:
 
@@ -84,84 +91,82 @@ jobs:
         envName: ${{ inputs.environmentId }}
         deployConfigPath: .deployment/theme/cloudDeploy.json
 
-    - name: Start deployment
-      uses: bobheadxi/deployments@main
-      id: deployment
-      with:
-        step: start
-        token: ${{ env.GITHUB_TOKEN }}
-        env: ${{ steps.deployConfig.outputs.environmentName }}
-        override: true
+    # - name: Start deployment
+    #   uses: bobheadxi/deployments@main
+    #   id: deployment
+    #   with:
+    #     step: start
+    #     token: ${{ env.GITHUB_TOKEN }}
+    #     env: ${{ steps.deployConfig.outputs.environmentName }}
+    #     override: true
 
-    - name: Deploy to ${{ steps.deployConfig.outputs.environmentName }}
-      uses: VirtoCommerce/vc-github-actions/create-deploy-pr@master
-      with:
-        githubToken: ${{ env.GITHUB_TOKEN }}
-        deployRepo: ${{ steps.deployConfig.outputs.deployRepo }}
-        deployBranch: ${{ steps.deployConfig.outputs.deployBranch }}
-        cmPath: ${{ inputs.cmPath || steps.deployConfig.outputs.cmPath }}
-        artifactKey: '"${{ inputs.artifactKey || steps.deployConfig.outputs.artifactKey }}"'
-        artifactUrl: '"${{ inputs.artifactUrl }}"'
-        taskNumber: ${{ inputs.jiraKeys }}
-        forceCommit: ${{ inputs.forceCommit }}
+    # - name: Deploy to ${{ steps.deployConfig.outputs.environmentName }}
+    #   uses: VirtoCommerce/vc-github-actions/create-deploy-pr@master
+    #   with:
+    #     githubToken: ${{ env.GITHUB_TOKEN }}
+    #     deployRepo: ${{ steps.deployConfig.outputs.deployRepo }}
+    #     deployBranch: ${{ steps.deployConfig.outputs.deployBranch }}
+    #     cmPath: ${{ inputs.cmPath || steps.deployConfig.outputs.cmPath }}
+    #     artifactKey: '"${{ inputs.artifactKey || steps.deployConfig.outputs.artifactKey }}"'
+    #     artifactUrl: '"${{ inputs.artifactUrl }}"'
+    #     taskNumber: ${{ inputs.jiraKeys }}
+    #     forceCommit: ${{ inputs.forceCommit }}
 
-    - name: Sleep for ${{ env.SLEEP_TIME }}
-      if: ${{ inputs.forceCommit }}
-      run: sleep ${{ env.SLEEP_TIME }}
-      shell: bash
+    # - name: Sleep for ${{ env.SLEEP_TIME }}
+    #   if: ${{ inputs.forceCommit }}
+    #   run: sleep ${{ env.SLEEP_TIME }}
+    #   shell: bash
 
-    - name: Wait for environment is up
+    - name: Check deployment status
       if: ${{ inputs.forceCommit }}
       timeout-minutes: 5
-      uses: VirtoCommerce/vc-github-actions/vc-argocd-cli@master
-      with:
-        server: ${{ env.ARGO_SERVER }}
-        username: ${{ secrets.VIRTOCLOUD_LOGIN }}
-        password: ${{ secrets.VIRTOCLOUD_PASSWORD }}
-        command: app wait ${{ steps.deployConfig.outputs.deployAppName }}
+      run: |
+        dotnet tool install --global VirtoCommerce.GlobalTool || true
+        vc-build CloudEnvStatus -CloudUrl ${{ env.CLOUD_URL }} -CloudToken ${{ env.VIRTOCLOUD_KEY }} -EnvironmentName ${{ steps.deployConfig.outputs.deployAppName }} -HealthStatus Healthy -SyncStatus Synced
+      shell: bash
 
-    - name: DEPLOY_STATE::successful
-      if: success()
-      run: echo "DEPLOY_STATE=successful" >> $GITHUB_ENV
+    # - name: DEPLOY_STATE::successful
+    #   if: success()
+    #   run: echo "DEPLOY_STATE=successful" >> $GITHUB_ENV
 
-    - name: DEPLOY_STATE::failed
-      if: failure()
-      run: echo "DEPLOY_STATE=failed"  >> $GITHUB_ENV
+    # - name: DEPLOY_STATE::failed
+    #   if: failure()
+    #   run: echo "DEPLOY_STATE=failed"  >> $GITHUB_ENV
 
-    - name: Update GitHub deployment status
-      uses: bobheadxi/deployments@main
-      if: always()
-      with:
-        step: finish
-        token: ${{ env.GITHUB_TOKEN }}
-        status: ${{ job.status }}
-        env: ${{ steps.deployment.outputs.env }}
-        deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+    # - name: Update GitHub deployment status
+    #   uses: bobheadxi/deployments@main
+    #   if: always()
+    #   with:
+    #     step: finish
+    #     token: ${{ env.GITHUB_TOKEN }}
+    #     status: ${{ job.status }}
+    #     env: ${{ steps.deployment.outputs.env }}
+    #     deployment_id: ${{ steps.deployment.outputs.deployment_id }}
 
-    - name: Push Deployment Info to Jira
-      if: ${{ env.CLOUD_INSTANCE_BASE_URL != 0 && env.CLIENT_ID != 0 && env.CLIENT_SECRET != 0 && inputs.jiraKeys != '' && always() }}
-      id: push_deployment_info_to_jira
-      uses: VirtoCommerce/jira-upload-deployment-info@master
-      env:
-        CLOUD_INSTANCE_BASE_URL: ${{secrets.CLOUD_INSTANCE_BASE_URL}}
-        CLIENT_ID: ${{secrets.CLIENT_ID}}
-        CLIENT_SECRET: ${{secrets.CLIENT_SECRET}}
-      with:
-        cloud-instance-base-url: ${{ secrets.CLOUD_INSTANCE_BASE_URL }}
-        client-id: ${{ secrets.CLIENT_ID }}
-        client-secret: ${{ secrets.CLIENT_SECRET }}
-        deployment-sequence-number: ${{ github.run_id }}
-        update-sequence-number: ${{ github.run_id }}
-        issue-keys: ${{ inputs.jiraKeys }}
-        display-name: ${{ steps.deployConfig.outputs.deployAppName }}
-        url: ${{ steps.deployConfig.outputs.environmentUrl }}
-        label: ${{ steps.deployConfig.outputs.environmentName }}
-        description: 'Deployment to the ${{ steps.deployConfig.outputs.environmentName }} environment'
-        last-updated: '${{github.event.head_commit.timestamp}}'
-        state: '${{ env.DEPLOY_STATE }}'
-        pipeline-id: '${{ github.repository }} ${{ github.workflow }}'
-        pipeline-display-name: 'Workflow: ${{ github.workflow }} (#${{ github.run_number }})'
-        pipeline-url: '${{github.event.repository.html_url}}/actions/runs/${{github.run_id}}'
-        environment-id: ${{ steps.deployConfig.outputs.environmentId }}
-        environment-display-name: ${{ steps.deployConfig.outputs.environmentName }}
-        environment-type: ${{ steps.deployConfig.outputs.environmentType }}
+    # - name: Push Deployment Info to Jira
+    #   if: ${{ env.CLOUD_INSTANCE_BASE_URL != 0 && env.CLIENT_ID != 0 && env.CLIENT_SECRET != 0 && inputs.jiraKeys != '' && always() }}
+    #   id: push_deployment_info_to_jira
+    #   uses: VirtoCommerce/jira-upload-deployment-info@master
+    #   env:
+    #     CLOUD_INSTANCE_BASE_URL: ${{secrets.CLOUD_INSTANCE_BASE_URL}}
+    #     CLIENT_ID: ${{secrets.CLIENT_ID}}
+    #     CLIENT_SECRET: ${{secrets.CLIENT_SECRET}}
+    #   with:
+    #     cloud-instance-base-url: ${{ secrets.CLOUD_INSTANCE_BASE_URL }}
+    #     client-id: ${{ secrets.CLIENT_ID }}
+    #     client-secret: ${{ secrets.CLIENT_SECRET }}
+    #     deployment-sequence-number: ${{ github.run_id }}
+    #     update-sequence-number: ${{ github.run_id }}
+    #     issue-keys: ${{ inputs.jiraKeys }}
+    #     display-name: ${{ steps.deployConfig.outputs.deployAppName }}
+    #     url: ${{ steps.deployConfig.outputs.environmentUrl }}
+    #     label: ${{ steps.deployConfig.outputs.environmentName }}
+    #     description: 'Deployment to the ${{ steps.deployConfig.outputs.environmentName }} environment'
+    #     last-updated: '${{github.event.head_commit.timestamp}}'
+    #     state: '${{ env.DEPLOY_STATE }}'
+    #     pipeline-id: '${{ github.repository }} ${{ github.workflow }}'
+    #     pipeline-display-name: 'Workflow: ${{ github.workflow }} (#${{ github.run_number }})'
+    #     pipeline-url: '${{github.event.repository.html_url}}/actions/runs/${{github.run_id}}'
+    #     environment-id: ${{ steps.deployConfig.outputs.environmentId }}
+    #     environment-display-name: ${{ steps.deployConfig.outputs.environmentName }}
+    #     environment-type: ${{ steps.deployConfig.outputs.environmentType }}

--- a/.github/workflows/theme-ci.yml
+++ b/.github/workflows/theme-ci.yml
@@ -18,273 +18,273 @@ on:
       - 'LICENSE'
 
 jobs:
-  # ci:
-  #   if: ${{ github.actor != 'dependabot[bot]' &&
-  #        (github.event.pull_request.head.repo.full_name == github.repository ||
-  #        github.event.pull_request.head.repo.full_name == '') }}  # Check that PR not from forked repo and not from Dependabot
-  #   runs-on: ubuntu-latest
-  #   env:
-  #     FORCE_COLOR: true
-  #     CLOUD_INSTANCE_BASE_URL: ${{secrets.CLOUD_INSTANCE_BASE_URL}}
-  #     CLIENT_ID: ${{secrets.CLIENT_ID}}
-  #     CLIENT_SECRET: ${{secrets.CLIENT_SECRET}}
-  #     SONAR_TOKEN: ${{secrets.SONAR_TOKEN}}
-  #     GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
-  #     BLOB_SAS: ${{ secrets.BLOB_TOKEN }}
-  #     VERSION: ''
-  #     VERSION_SUFFIX: ''
-  #     BUILD_STATE: 'failed'
-  #     RELEASE_STATUS: 'false'
-  #   outputs:
-  #     artifactUrl: '${{ steps.artifactUrl.outputs.download_url }}'
-  #     jira-keys: ${{ steps.jira_keys.outputs.jira-keys }}
-  #     branchName: ${{ steps.branch_name.outputs.branchName }}
+  ci:
+    if: ${{ github.actor != 'dependabot[bot]' &&
+         (github.event.pull_request.head.repo.full_name == github.repository ||
+         github.event.pull_request.head.repo.full_name == '') }}  # Check that PR not from forked repo and not from Dependabot
+    runs-on: ubuntu-latest
+    env:
+      FORCE_COLOR: true
+      CLOUD_INSTANCE_BASE_URL: ${{secrets.CLOUD_INSTANCE_BASE_URL}}
+      CLIENT_ID: ${{secrets.CLIENT_ID}}
+      CLIENT_SECRET: ${{secrets.CLIENT_SECRET}}
+      SONAR_TOKEN: ${{secrets.SONAR_TOKEN}}
+      GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
+      BLOB_SAS: ${{ secrets.BLOB_TOKEN }}
+      VERSION: ''
+      VERSION_SUFFIX: ''
+      BUILD_STATE: 'failed'
+      RELEASE_STATUS: 'false'
+    outputs:
+      artifactUrl: '${{ steps.artifactUrl.outputs.download_url }}'
+      jira-keys: ${{ steps.jira_keys.outputs.jira-keys }}
+      branchName: ${{ steps.branch_name.outputs.branchName }}
 
-  #   steps:
+    steps:
 
-  #     - name: Set up Node 22
-  #       uses: actions/setup-node@v4.2.0
-  #       with:
-  #         node-version: '22'
+      - name: Set up Node 22
+        uses: actions/setup-node@v4.2.0
+        with:
+          node-version: '22'
 
-  #     - name: Enable corepack
-  #       run: |
-  #         corepack enable
+      - name: Enable corepack
+        run: |
+          corepack enable
 
-  #     - name: Set RELEASE_STATUS
-  #       if: ${{ github.ref == 'refs/heads/master' && github.event_name == 'push' }}
-  #       run: |
-  #         echo "RELEASE_STATUS=true" >> $GITHUB_ENV
+      - name: Set RELEASE_STATUS
+        if: ${{ github.ref == 'refs/heads/master' && github.event_name == 'push' }}
+        run: |
+          echo "RELEASE_STATUS=true" >> $GITHUB_ENV
 
-  #     - uses: actions/checkout@v4
-  #       with:
-  #         fetch-depth: 0
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-  #     - name: Get Image Version
-  #       uses: VirtoCommerce/vc-github-actions/get-image-version@master
-  #       with:
-  #         projectType: theme
-  #       id: image
+      - name: Get Image Version
+        uses: VirtoCommerce/vc-github-actions/get-image-version@master
+        with:
+          projectType: theme
+        id: image
 
-  #     - name: Get changelog
-  #       id: changelog
-  #       uses: VirtoCommerce/vc-github-actions/changelog-generator@master
+      - name: Get changelog
+        id: changelog
+        uses: VirtoCommerce/vc-github-actions/changelog-generator@master
 
-  #     - name: Set release VERSION_SUFFIX
-  #       run: |
-  #         echo "VERSION_SUFFIX=${{ steps.image.outputs.suffix }}" >> $GITHUB_ENV
+      - name: Set release VERSION_SUFFIX
+        run: |
+          echo "VERSION_SUFFIX=${{ steps.image.outputs.suffix }}" >> $GITHUB_ENV
 
-  #     - name: Set release-alpha VERSION_SUFFIX
-  #       if: ${{ github.event_name == 'workflow_dispatch' }}
-  #       run: |
-  #         echo "VERSION_SUFFIX=${{ steps.image.outputs.fullSuffix }}" >> $GITHUB_ENV
+      - name: Set release-alpha VERSION_SUFFIX
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          echo "VERSION_SUFFIX=${{ steps.image.outputs.fullSuffix }}" >> $GITHUB_ENV
 
-  #     - name: Set PR VERSION_SUFFIX
-  #       if: ${{ github.event_name == 'pull_request' }}
-  #       run: |
-  #         echo "VERSION_SUFFIX=${{ steps.image.outputs.suffix }}-${{ steps.image.outputs.SHA }}" >> $GITHUB_ENV
+      - name: Set PR VERSION_SUFFIX
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          echo "VERSION_SUFFIX=${{ steps.image.outputs.suffix }}-${{ steps.image.outputs.SHA }}" >> $GITHUB_ENV
 
-  #     - name: Set VERSION
-  #       run: |
-  #         echo "VERSION=${{ steps.image.outputs.prefix }}${{ env.VERSION_SUFFIX && '-' || '' }}${{ env.VERSION_SUFFIX }}" >> $GITHUB_ENV
+      - name: Set VERSION
+        run: |
+          echo "VERSION=${{ steps.image.outputs.prefix }}${{ env.VERSION_SUFFIX && '-' || '' }}${{ env.VERSION_SUFFIX }}" >> $GITHUB_ENV
 
-  #     - name: Update package.json Version
-  #       run: |
-  #         yarn version ${{ env.VERSION }}
+      - name: Update package.json Version
+        run: |
+          yarn version ${{ env.VERSION }}
 
-  #     - name: Install dependencies
-  #       run: |
-  #         yarn install
+      - name: Install dependencies
+        run: |
+          yarn install
 
-  #     - name: SonarCloud Scan
-  #       uses: SonarSource/sonarqube-scan-action@v5.3.1
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarqube-scan-action@v5.3.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
-  #     - name: Check Locales
-  #       run: |
-  #         set -o pipefail
-  #         yarn check-locales 2>&1 | tee check-locales.log
-  #         if grep -q "Warning:" check-locales.log; then
-  #           echo "Locale check completed with warnings."
-  #           exit 1
-  #         fi
+      - name: Check Locales
+        run: |
+          set -o pipefail
+          yarn check-locales 2>&1 | tee check-locales.log
+          if grep -q "Warning:" check-locales.log; then
+            echo "Locale check completed with warnings."
+            exit 1
+          fi
 
-  #     - name: Build
-  #       run: |
-  #         yarn build
+      - name: Build
+        run: |
+          yarn build
 
-  #     - name: Unit Tests with Coverage
-  #       run: |
-  #         yarn test:coverage
+      - name: Unit Tests with Coverage
+        run: |
+          yarn test:coverage
 
-  #     - name: Upload Coverage Report
-  #       uses:  actions/upload-artifact@v4
-  #       with:
-  #         name: coverage-report
-  #         path: coverage
+      - name: Upload Coverage Report
+        uses:  actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage
 
-  #     - name: Typing Tests
-  #       run: |
-  #         yarn test:typing --run
+      - name: Typing Tests
+        run: |
+          yarn test:typing --run
 
-  #     - name: BUILD_STATE::successful
-  #       if: success()
-  #       run: echo "BUILD_STATE=successful" >> $GITHUB_ENV
+      - name: BUILD_STATE::successful
+        if: success()
+        run: echo "BUILD_STATE=successful" >> $GITHUB_ENV
 
-  #     - name: Add files to zip
-  #       run: |
-  #         mkdir -p ./tmp/default
-  #         mkdir ./artifacts
-  #         mv ./dist/* ./tmp/default
-  #         cd ./tmp
-  #         zip -r ../artifacts/$(jq -r .name ../package.json)-$(jq -r .version ../package.json).zip ./default
+      - name: Add files to zip
+        run: |
+          mkdir -p ./tmp/default
+          mkdir ./artifacts
+          mv ./dist/* ./tmp/default
+          cd ./tmp
+          zip -r ../artifacts/$(jq -r .name ../package.json)-$(jq -r .version ../package.json).zip ./default
 
-  #     - name: Publish to Blob
-  #       if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/master')}}
-  #       id: blobRelease
-  #       uses: VirtoCommerce/vc-github-actions/publish-blob-release@master
-  #       with:
-  #         blobSAS: ${{ secrets.BLOB_TOKEN }}
-  #         blobUrl: ${{ vars.BLOB_URL }}
+      - name: Publish to Blob
+        if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/master')}}
+        id: blobRelease
+        uses: VirtoCommerce/vc-github-actions/publish-blob-release@master
+        with:
+          blobSAS: ${{ secrets.BLOB_TOKEN }}
+          blobUrl: ${{ vars.BLOB_URL }}
 
-  #     - name: Add link to PR
-  #       if: ${{ github.event_name == 'pull_request' }}
-  #       uses: VirtoCommerce/vc-github-actions/publish-artifact-link@master
-  #       with:
-  #         artifactUrl: ${{ steps.blobRelease.outputs.packageUrl }}
-  #         repoOrg: ${{ github.repository_owner }}
-  #         downloadComment: 'Artifact URL:'
+      - name: Add link to PR
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: VirtoCommerce/vc-github-actions/publish-artifact-link@master
+        with:
+          artifactUrl: ${{ steps.blobRelease.outputs.packageUrl }}
+          repoOrg: ${{ github.repository_owner }}
+          downloadComment: 'Artifact URL:'
 
-  #     - name: Release
-  #       uses: softprops/action-gh-release@v2
-  #       id: create_release
-  #       if: ${{ github.ref == 'refs/heads/master' }}
-  #       with:
-  #         make_latest: true
-  #         name: ${{ steps.image.outputs.prefix }}
-  #         draft: false
-  #         prerelease: false
-  #         body: "[Compatible environment configuration](https://github.com/VirtoCommerce/vc-deploy-dev/releases/tag/v${{ steps.image.outputs.prefix }}_vc-frontend)"
-  #         tag_name: ${{ steps.image.outputs.prefix }}
-  #         files: artifacts/${{ steps.blobRelease.outputs.blobId }}
-  #         target_commitish: ${{ github.ref_name }}
-  #         generate_release_notes: true
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        id: create_release
+        if: ${{ github.ref == 'refs/heads/master' }}
+        with:
+          make_latest: true
+          name: ${{ steps.image.outputs.prefix }}
+          draft: false
+          prerelease: false
+          body: "[Compatible environment configuration](https://github.com/VirtoCommerce/vc-deploy-dev/releases/tag/v${{ steps.image.outputs.prefix }}_vc-frontend)"
+          tag_name: ${{ steps.image.outputs.prefix }}
+          files: artifacts/${{ steps.blobRelease.outputs.blobId }}
+          target_commitish: ${{ github.ref_name }}
+          generate_release_notes: true
 
-  #     - name: Set artifactUrl value
-  #       id: artifactUrl
-  #       run: |
-  #         if [ '${{ github.ref }}' = 'refs/heads/master' ]; then
-  #           download_url=$(echo '${{ steps.create_release.outputs.assets }}' | jq -r '.[0].browser_download_url // empty')
-  #           if [ -n "$download_url" ]; then
-  #             echo "download_url=$download_url" >> $GITHUB_OUTPUT
-  #           else
-  #             echo "download_url=" >> $GITHUB_OUTPUT
-  #           fi
-  #         else
-  #           echo "download_url=${{ steps.blobRelease.outputs.packageUrl }}" >> $GITHUB_OUTPUT
-  #         fi
+      - name: Set artifactUrl value
+        id: artifactUrl
+        run: |
+          if [ '${{ github.ref }}' = 'refs/heads/master' ]; then
+            download_url=$(echo '${{ steps.create_release.outputs.assets }}' | jq -r '.[0].browser_download_url // empty')
+            if [ -n "$download_url" ]; then
+              echo "download_url=$download_url" >> $GITHUB_OUTPUT
+            else
+              echo "download_url=" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "download_url=${{ steps.blobRelease.outputs.packageUrl }}" >> $GITHUB_OUTPUT
+          fi
 
-  #     - name: Parse Jira Keys from All Commits
-  #       uses: VirtoCommerce/vc-github-actions/get-jira-keys@master
-  #       if: always()
-  #       id: jira_keys
-  #       with:
-  #         release: ${{ env.RELEASE_STATUS }}
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Parse Jira Keys from All Commits
+        uses: VirtoCommerce/vc-github-actions/get-jira-keys@master
+        if: always()
+        id: jira_keys
+        with:
+          release: ${{ env.RELEASE_STATUS }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  #     - name: Push Build Info to Jira
-  #       if: ${{ env.CLOUD_INSTANCE_BASE_URL != 0 && env.CLIENT_ID != 0 && env.CLIENT_SECRET != 0 && steps.jira_keys.outputs.jira-keys != '' && always() }}
-  #       id: push_build_info_to_jira
-  #       uses: VirtoCommerce/jira-upload-build-info@master
-  #       with:
-  #         cloud-instance-base-url: '${{ secrets.CLOUD_INSTANCE_BASE_URL }}'
-  #         client-id: '${{ secrets.CLIENT_ID }}'
-  #         client-secret: '${{ secrets.CLIENT_SECRET }}'
-  #         pipeline-id: '${{ github.repository }} ${{ github.workflow }}'
-  #         build-number: ${{ github.run_number }}
-  #         build-display-name: 'Workflow: ${{ github.workflow }} (#${{ github.run_number }})'
-  #         build-state: '${{ env.BUILD_STATE }}'
-  #         build-url: '${{github.event.repository.url}}/actions/runs/${{github.run_id}}'
-  #         update-sequence-number: '${{ github.run_id }}'
-  #         last-updated: '${{github.event.head_commit.timestamp}}'
-  #         issue-keys: '${{ steps.jira_keys.outputs.jira-keys }}'
-  #         commit-id: '${{ github.sha }}'
-  #         repo-url: '${{ github.event.repository.url }}'
-  #         build-ref-url: '${{ github.event.repository.url }}/actions/runs/${{ github.run_id }}'
+      - name: Push Build Info to Jira
+        if: ${{ env.CLOUD_INSTANCE_BASE_URL != 0 && env.CLIENT_ID != 0 && env.CLIENT_SECRET != 0 && steps.jira_keys.outputs.jira-keys != '' && always() }}
+        id: push_build_info_to_jira
+        uses: VirtoCommerce/jira-upload-build-info@master
+        with:
+          cloud-instance-base-url: '${{ secrets.CLOUD_INSTANCE_BASE_URL }}'
+          client-id: '${{ secrets.CLIENT_ID }}'
+          client-secret: '${{ secrets.CLIENT_SECRET }}'
+          pipeline-id: '${{ github.repository }} ${{ github.workflow }}'
+          build-number: ${{ github.run_number }}
+          build-display-name: 'Workflow: ${{ github.workflow }} (#${{ github.run_number }})'
+          build-state: '${{ env.BUILD_STATE }}'
+          build-url: '${{github.event.repository.url}}/actions/runs/${{github.run_id}}'
+          update-sequence-number: '${{ github.run_id }}'
+          last-updated: '${{github.event.head_commit.timestamp}}'
+          issue-keys: '${{ steps.jira_keys.outputs.jira-keys }}'
+          commit-id: '${{ github.sha }}'
+          repo-url: '${{ github.event.repository.url }}'
+          build-ref-url: '${{ github.event.repository.url }}/actions/runs/${{ github.run_id }}'
 
-  #     - name: Confirm Jira Build Output
-  #       if: success()
-  #       run: |
-  #         echo "Jira Upload Build Info response: ${{ steps.push_build_info_to_jira.outputs.response }}"
+      - name: Confirm Jira Build Output
+        if: success()
+        run: |
+          echo "Jira Upload Build Info response: ${{ steps.push_build_info_to_jira.outputs.response }}"
 
-  #     - name: Update Jira Tasks with Release Number
-  #       if: ${{ github.ref == 'refs/heads/master' }}
-  #       uses: VirtoCommerce/vc-github-actions/update-jira-tasks-with-release-number@master
-  #       with:
-  #         ghRepository: ${{ github.repository }}
-  #         ghReleaseTag: ${{ steps.image.outputs.prefix }}
-  #         jiraCustomFieldId: 'customfield_10297' # 'customfield_10297' corresponds to 'Theme release' field
-  #         jiraCustomFieldValue: "${{ steps.image.outputs.prefix }}"
-  #         client-id: '${{ secrets.JIRA_USER }}'
-  #         client-secret: '${{ secrets.JIRA_TOKEN }}'
+      - name: Update Jira Tasks with Release Number
+        if: ${{ github.ref == 'refs/heads/master' }}
+        uses: VirtoCommerce/vc-github-actions/update-jira-tasks-with-release-number@master
+        with:
+          ghRepository: ${{ github.repository }}
+          ghReleaseTag: ${{ steps.image.outputs.prefix }}
+          jiraCustomFieldId: 'customfield_10297' # 'customfield_10297' corresponds to 'Theme release' field
+          jiraCustomFieldValue: "${{ steps.image.outputs.prefix }}"
+          client-id: '${{ secrets.JIRA_USER }}'
+          client-secret: '${{ secrets.JIRA_TOKEN }}'
 
-  #     - name: Set branch name value
-  #       if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
-  #         (github.event_name == 'workflow_dispatch') || ((github.base_ref == 'dev') && (github.event_name == 'pull_request')) }}
-  #       id: branch_name
-  #       shell: pwsh
-  #       env:
-  #         EVENT_NAME: ${{ github.event_name }}
-  #         HEAD_REF: ${{ github.head_ref }}
-  #         REF_NAME: ${{ github.ref_name }}
-  #       run: |
-  #         if ($env:EVENT_NAME -eq 'pull_request'){
-  #           $branchName = $env:HEAD_REF
-  #         } else {
-  #           $branchName = $env:REF_NAME
-  #         }
-  #         Add-Content -Path $env:GITHUB_OUTPUT -Value "branchName=$branchName"
+      - name: Set branch name value
+        if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
+          (github.event_name == 'workflow_dispatch') || ((github.base_ref == 'dev') && (github.event_name == 'pull_request')) }}
+        id: branch_name
+        shell: pwsh
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_REF: ${{ github.head_ref }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          if ($env:EVENT_NAME -eq 'pull_request'){
+            $branchName = $env:HEAD_REF
+          } else {
+            $branchName = $env:REF_NAME
+          }
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "branchName=$branchName"
 
-  # ui-e2e-auto-tests:
-  #   needs: 'ci'
-  #   if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
-  #       (github.event_name == 'workflow_dispatch') || (github.base_ref == 'dev') && (github.event_name == 'pull_request') }}
-  #   uses: VirtoCommerce/.github/.github/workflows/e2e-autotests.yml@v3.800.23
-  #   with:
-  #     installModules: 'false'
-  #     installCustomModule: 'false'
-  #     runTests: 'true'
-  #     vctestingRepoBranch: 'dev'
-  #     frontendZipUrl: '${{ needs.ci.outputs.artifactUrl }}'
-  #     customPackagesJsonUrl: 'https://github.com/${{ github.repository }}/raw/${{ needs.ci.outputs.branchName }}/backend-packages.json'
-  #   secrets:
-  #     envPAT: ${{ secrets.REPO_TOKEN }}
-  #     testSecretEnvFile: ${{ secrets.VC_TESTING_MODULE_ENV_FILE }}
-  #     sendgridApiKey: ${{ secrets.SENDGRID_APIKEY_4E2E_AUTOTESTS }}
+  ui-e2e-auto-tests:
+    needs: 'ci'
+    if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
+        (github.event_name == 'workflow_dispatch') || (github.base_ref == 'dev') && (github.event_name == 'pull_request') }}
+    uses: VirtoCommerce/.github/.github/workflows/e2e-autotests.yml@v3.800.23
+    with:
+      installModules: 'false'
+      installCustomModule: 'false'
+      runTests: 'true'
+      vctestingRepoBranch: 'dev'
+      frontendZipUrl: '${{ needs.ci.outputs.artifactUrl }}'
+      customPackagesJsonUrl: 'https://github.com/${{ github.repository }}/raw/${{ needs.ci.outputs.branchName }}/backend-packages.json'
+    secrets:
+      envPAT: ${{ secrets.REPO_TOKEN }}
+      testSecretEnvFile: ${{ secrets.VC_TESTING_MODULE_ENV_FILE }}
+      sendgridApiKey: ${{ secrets.SENDGRID_APIKEY_4E2E_AUTOTESTS }}
 
-  # ui-auto-tests:
-  #   needs: 'ci'
-  #   if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
-  #     (github.base_ref == 'dev') && (github.event_name == 'pull_request') || 
-  #     (github.event_name == 'workflow_dispatch') }}
-  #   uses: VirtoCommerce/.github/.github/workflows/ui-autotests.yml@v3.800.23
-  #   with:
-  #     installModules: 'true'
-  #     installCustomModule: 'false'
-  #     platformDockerTag: 'linux-latest'
-  #     frontendZipUrl: '${{ needs.ci.outputs.artifactUrl }}'
-  #     vctestingRepoBranch: 'dev'
-  #   secrets:
-  #     envPAT: ${{ secrets.REPO_TOKEN }}
-  #     testSecretEnvFile: ${{ secrets.VC_TESTING_MODULE_ENV_FILE }}
-  #     sendgridApiKey: ${{ secrets.SENDGRID_APIKEY_4E2E_AUTOTESTS }}
+  ui-auto-tests:
+    needs: 'ci'
+    if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
+      (github.base_ref == 'dev') && (github.event_name == 'pull_request') || 
+      (github.event_name == 'workflow_dispatch') }}
+    uses: VirtoCommerce/.github/.github/workflows/ui-autotests.yml@v3.800.23
+    with:
+      installModules: 'true'
+      installCustomModule: 'false'
+      platformDockerTag: 'linux-latest'
+      frontendZipUrl: '${{ needs.ci.outputs.artifactUrl }}'
+      vctestingRepoBranch: 'dev'
+    secrets:
+      envPAT: ${{ secrets.REPO_TOKEN }}
+      testSecretEnvFile: ${{ secrets.VC_TESTING_MODULE_ENV_FILE }}
+      sendgridApiKey: ${{ secrets.SENDGRID_APIKEY_4E2E_AUTOTESTS }}
 
   deploy-cloud:
-    # if: ${{ github.ref == 'refs/heads/dev' || github.event_name == 'pull_request'}}
-    # needs: ci
+    if: ${{ github.ref == 'refs/heads/dev' || github.event_name == 'pull_request'}}
+    needs: ci
     uses: ./.github/workflows/deploy-cloud.yml
     with:
       cmPath: 'theme/artifact.json'

--- a/.github/workflows/theme-ci.yml
+++ b/.github/workflows/theme-ci.yml
@@ -18,273 +18,273 @@ on:
       - 'LICENSE'
 
 jobs:
-  ci:
-    if: ${{ github.actor != 'dependabot[bot]' &&
-         (github.event.pull_request.head.repo.full_name == github.repository ||
-         github.event.pull_request.head.repo.full_name == '') }}  # Check that PR not from forked repo and not from Dependabot
-    runs-on: ubuntu-latest
-    env:
-      FORCE_COLOR: true
-      CLOUD_INSTANCE_BASE_URL: ${{secrets.CLOUD_INSTANCE_BASE_URL}}
-      CLIENT_ID: ${{secrets.CLIENT_ID}}
-      CLIENT_SECRET: ${{secrets.CLIENT_SECRET}}
-      SONAR_TOKEN: ${{secrets.SONAR_TOKEN}}
-      GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
-      BLOB_SAS: ${{ secrets.BLOB_TOKEN }}
-      VERSION: ''
-      VERSION_SUFFIX: ''
-      BUILD_STATE: 'failed'
-      RELEASE_STATUS: 'false'
-    outputs:
-      artifactUrl: '${{ steps.artifactUrl.outputs.download_url }}'
-      jira-keys: ${{ steps.jira_keys.outputs.jira-keys }}
-      branchName: ${{ steps.branch_name.outputs.branchName }}
+  # ci:
+  #   if: ${{ github.actor != 'dependabot[bot]' &&
+  #        (github.event.pull_request.head.repo.full_name == github.repository ||
+  #        github.event.pull_request.head.repo.full_name == '') }}  # Check that PR not from forked repo and not from Dependabot
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     FORCE_COLOR: true
+  #     CLOUD_INSTANCE_BASE_URL: ${{secrets.CLOUD_INSTANCE_BASE_URL}}
+  #     CLIENT_ID: ${{secrets.CLIENT_ID}}
+  #     CLIENT_SECRET: ${{secrets.CLIENT_SECRET}}
+  #     SONAR_TOKEN: ${{secrets.SONAR_TOKEN}}
+  #     GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
+  #     BLOB_SAS: ${{ secrets.BLOB_TOKEN }}
+  #     VERSION: ''
+  #     VERSION_SUFFIX: ''
+  #     BUILD_STATE: 'failed'
+  #     RELEASE_STATUS: 'false'
+  #   outputs:
+  #     artifactUrl: '${{ steps.artifactUrl.outputs.download_url }}'
+  #     jira-keys: ${{ steps.jira_keys.outputs.jira-keys }}
+  #     branchName: ${{ steps.branch_name.outputs.branchName }}
 
-    steps:
+  #   steps:
 
-      - name: Set up Node 22
-        uses: actions/setup-node@v4.2.0
-        with:
-          node-version: '22'
+  #     - name: Set up Node 22
+  #       uses: actions/setup-node@v4.2.0
+  #       with:
+  #         node-version: '22'
 
-      - name: Enable corepack
-        run: |
-          corepack enable
+  #     - name: Enable corepack
+  #       run: |
+  #         corepack enable
 
-      - name: Set RELEASE_STATUS
-        if: ${{ github.ref == 'refs/heads/master' && github.event_name == 'push' }}
-        run: |
-          echo "RELEASE_STATUS=true" >> $GITHUB_ENV
+  #     - name: Set RELEASE_STATUS
+  #       if: ${{ github.ref == 'refs/heads/master' && github.event_name == 'push' }}
+  #       run: |
+  #         echo "RELEASE_STATUS=true" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 0
 
-      - name: Get Image Version
-        uses: VirtoCommerce/vc-github-actions/get-image-version@master
-        with:
-          projectType: theme
-        id: image
+  #     - name: Get Image Version
+  #       uses: VirtoCommerce/vc-github-actions/get-image-version@master
+  #       with:
+  #         projectType: theme
+  #       id: image
 
-      - name: Get changelog
-        id: changelog
-        uses: VirtoCommerce/vc-github-actions/changelog-generator@master
+  #     - name: Get changelog
+  #       id: changelog
+  #       uses: VirtoCommerce/vc-github-actions/changelog-generator@master
 
-      - name: Set release VERSION_SUFFIX
-        run: |
-          echo "VERSION_SUFFIX=${{ steps.image.outputs.suffix }}" >> $GITHUB_ENV
+  #     - name: Set release VERSION_SUFFIX
+  #       run: |
+  #         echo "VERSION_SUFFIX=${{ steps.image.outputs.suffix }}" >> $GITHUB_ENV
 
-      - name: Set release-alpha VERSION_SUFFIX
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: |
-          echo "VERSION_SUFFIX=${{ steps.image.outputs.fullSuffix }}" >> $GITHUB_ENV
+  #     - name: Set release-alpha VERSION_SUFFIX
+  #       if: ${{ github.event_name == 'workflow_dispatch' }}
+  #       run: |
+  #         echo "VERSION_SUFFIX=${{ steps.image.outputs.fullSuffix }}" >> $GITHUB_ENV
 
-      - name: Set PR VERSION_SUFFIX
-        if: ${{ github.event_name == 'pull_request' }}
-        run: |
-          echo "VERSION_SUFFIX=${{ steps.image.outputs.suffix }}-${{ steps.image.outputs.SHA }}" >> $GITHUB_ENV
+  #     - name: Set PR VERSION_SUFFIX
+  #       if: ${{ github.event_name == 'pull_request' }}
+  #       run: |
+  #         echo "VERSION_SUFFIX=${{ steps.image.outputs.suffix }}-${{ steps.image.outputs.SHA }}" >> $GITHUB_ENV
 
-      - name: Set VERSION
-        run: |
-          echo "VERSION=${{ steps.image.outputs.prefix }}${{ env.VERSION_SUFFIX && '-' || '' }}${{ env.VERSION_SUFFIX }}" >> $GITHUB_ENV
+  #     - name: Set VERSION
+  #       run: |
+  #         echo "VERSION=${{ steps.image.outputs.prefix }}${{ env.VERSION_SUFFIX && '-' || '' }}${{ env.VERSION_SUFFIX }}" >> $GITHUB_ENV
 
-      - name: Update package.json Version
-        run: |
-          yarn version ${{ env.VERSION }}
+  #     - name: Update package.json Version
+  #       run: |
+  #         yarn version ${{ env.VERSION }}
 
-      - name: Install dependencies
-        run: |
-          yarn install
+  #     - name: Install dependencies
+  #       run: |
+  #         yarn install
 
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@v5.3.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+  #     - name: SonarCloud Scan
+  #       uses: SonarSource/sonarqube-scan-action@v5.3.1
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
-      - name: Check Locales
-        run: |
-          set -o pipefail
-          yarn check-locales 2>&1 | tee check-locales.log
-          if grep -q "Warning:" check-locales.log; then
-            echo "Locale check completed with warnings."
-            exit 1
-          fi
+  #     - name: Check Locales
+  #       run: |
+  #         set -o pipefail
+  #         yarn check-locales 2>&1 | tee check-locales.log
+  #         if grep -q "Warning:" check-locales.log; then
+  #           echo "Locale check completed with warnings."
+  #           exit 1
+  #         fi
 
-      - name: Build
-        run: |
-          yarn build
+  #     - name: Build
+  #       run: |
+  #         yarn build
 
-      - name: Unit Tests with Coverage
-        run: |
-          yarn test:coverage
+  #     - name: Unit Tests with Coverage
+  #       run: |
+  #         yarn test:coverage
 
-      - name: Upload Coverage Report
-        uses:  actions/upload-artifact@v4
-        with:
-          name: coverage-report
-          path: coverage
+  #     - name: Upload Coverage Report
+  #       uses:  actions/upload-artifact@v4
+  #       with:
+  #         name: coverage-report
+  #         path: coverage
 
-      - name: Typing Tests
-        run: |
-          yarn test:typing --run
+  #     - name: Typing Tests
+  #       run: |
+  #         yarn test:typing --run
 
-      - name: BUILD_STATE::successful
-        if: success()
-        run: echo "BUILD_STATE=successful" >> $GITHUB_ENV
+  #     - name: BUILD_STATE::successful
+  #       if: success()
+  #       run: echo "BUILD_STATE=successful" >> $GITHUB_ENV
 
-      - name: Add files to zip
-        run: |
-          mkdir -p ./tmp/default
-          mkdir ./artifacts
-          mv ./dist/* ./tmp/default
-          cd ./tmp
-          zip -r ../artifacts/$(jq -r .name ../package.json)-$(jq -r .version ../package.json).zip ./default
+  #     - name: Add files to zip
+  #       run: |
+  #         mkdir -p ./tmp/default
+  #         mkdir ./artifacts
+  #         mv ./dist/* ./tmp/default
+  #         cd ./tmp
+  #         zip -r ../artifacts/$(jq -r .name ../package.json)-$(jq -r .version ../package.json).zip ./default
 
-      - name: Publish to Blob
-        if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/master')}}
-        id: blobRelease
-        uses: VirtoCommerce/vc-github-actions/publish-blob-release@master
-        with:
-          blobSAS: ${{ secrets.BLOB_TOKEN }}
-          blobUrl: ${{ vars.BLOB_URL }}
+  #     - name: Publish to Blob
+  #       if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/master')}}
+  #       id: blobRelease
+  #       uses: VirtoCommerce/vc-github-actions/publish-blob-release@master
+  #       with:
+  #         blobSAS: ${{ secrets.BLOB_TOKEN }}
+  #         blobUrl: ${{ vars.BLOB_URL }}
 
-      - name: Add link to PR
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: VirtoCommerce/vc-github-actions/publish-artifact-link@master
-        with:
-          artifactUrl: ${{ steps.blobRelease.outputs.packageUrl }}
-          repoOrg: ${{ github.repository_owner }}
-          downloadComment: 'Artifact URL:'
+  #     - name: Add link to PR
+  #       if: ${{ github.event_name == 'pull_request' }}
+  #       uses: VirtoCommerce/vc-github-actions/publish-artifact-link@master
+  #       with:
+  #         artifactUrl: ${{ steps.blobRelease.outputs.packageUrl }}
+  #         repoOrg: ${{ github.repository_owner }}
+  #         downloadComment: 'Artifact URL:'
 
-      - name: Release
-        uses: softprops/action-gh-release@v2
-        id: create_release
-        if: ${{ github.ref == 'refs/heads/master' }}
-        with:
-          make_latest: true
-          name: ${{ steps.image.outputs.prefix }}
-          draft: false
-          prerelease: false
-          body: "[Compatible environment configuration](https://github.com/VirtoCommerce/vc-deploy-dev/releases/tag/v${{ steps.image.outputs.prefix }}_vc-frontend)"
-          tag_name: ${{ steps.image.outputs.prefix }}
-          files: artifacts/${{ steps.blobRelease.outputs.blobId }}
-          target_commitish: ${{ github.ref_name }}
-          generate_release_notes: true
+  #     - name: Release
+  #       uses: softprops/action-gh-release@v2
+  #       id: create_release
+  #       if: ${{ github.ref == 'refs/heads/master' }}
+  #       with:
+  #         make_latest: true
+  #         name: ${{ steps.image.outputs.prefix }}
+  #         draft: false
+  #         prerelease: false
+  #         body: "[Compatible environment configuration](https://github.com/VirtoCommerce/vc-deploy-dev/releases/tag/v${{ steps.image.outputs.prefix }}_vc-frontend)"
+  #         tag_name: ${{ steps.image.outputs.prefix }}
+  #         files: artifacts/${{ steps.blobRelease.outputs.blobId }}
+  #         target_commitish: ${{ github.ref_name }}
+  #         generate_release_notes: true
 
-      - name: Set artifactUrl value
-        id: artifactUrl
-        run: |
-          if [ '${{ github.ref }}' = 'refs/heads/master' ]; then
-            download_url=$(echo '${{ steps.create_release.outputs.assets }}' | jq -r '.[0].browser_download_url // empty')
-            if [ -n "$download_url" ]; then
-              echo "download_url=$download_url" >> $GITHUB_OUTPUT
-            else
-              echo "download_url=" >> $GITHUB_OUTPUT
-            fi
-          else
-            echo "download_url=${{ steps.blobRelease.outputs.packageUrl }}" >> $GITHUB_OUTPUT
-          fi
+  #     - name: Set artifactUrl value
+  #       id: artifactUrl
+  #       run: |
+  #         if [ '${{ github.ref }}' = 'refs/heads/master' ]; then
+  #           download_url=$(echo '${{ steps.create_release.outputs.assets }}' | jq -r '.[0].browser_download_url // empty')
+  #           if [ -n "$download_url" ]; then
+  #             echo "download_url=$download_url" >> $GITHUB_OUTPUT
+  #           else
+  #             echo "download_url=" >> $GITHUB_OUTPUT
+  #           fi
+  #         else
+  #           echo "download_url=${{ steps.blobRelease.outputs.packageUrl }}" >> $GITHUB_OUTPUT
+  #         fi
 
-      - name: Parse Jira Keys from All Commits
-        uses: VirtoCommerce/vc-github-actions/get-jira-keys@master
-        if: always()
-        id: jira_keys
-        with:
-          release: ${{ env.RELEASE_STATUS }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #     - name: Parse Jira Keys from All Commits
+  #       uses: VirtoCommerce/vc-github-actions/get-jira-keys@master
+  #       if: always()
+  #       id: jira_keys
+  #       with:
+  #         release: ${{ env.RELEASE_STATUS }}
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Push Build Info to Jira
-        if: ${{ env.CLOUD_INSTANCE_BASE_URL != 0 && env.CLIENT_ID != 0 && env.CLIENT_SECRET != 0 && steps.jira_keys.outputs.jira-keys != '' && always() }}
-        id: push_build_info_to_jira
-        uses: VirtoCommerce/jira-upload-build-info@master
-        with:
-          cloud-instance-base-url: '${{ secrets.CLOUD_INSTANCE_BASE_URL }}'
-          client-id: '${{ secrets.CLIENT_ID }}'
-          client-secret: '${{ secrets.CLIENT_SECRET }}'
-          pipeline-id: '${{ github.repository }} ${{ github.workflow }}'
-          build-number: ${{ github.run_number }}
-          build-display-name: 'Workflow: ${{ github.workflow }} (#${{ github.run_number }})'
-          build-state: '${{ env.BUILD_STATE }}'
-          build-url: '${{github.event.repository.url}}/actions/runs/${{github.run_id}}'
-          update-sequence-number: '${{ github.run_id }}'
-          last-updated: '${{github.event.head_commit.timestamp}}'
-          issue-keys: '${{ steps.jira_keys.outputs.jira-keys }}'
-          commit-id: '${{ github.sha }}'
-          repo-url: '${{ github.event.repository.url }}'
-          build-ref-url: '${{ github.event.repository.url }}/actions/runs/${{ github.run_id }}'
+  #     - name: Push Build Info to Jira
+  #       if: ${{ env.CLOUD_INSTANCE_BASE_URL != 0 && env.CLIENT_ID != 0 && env.CLIENT_SECRET != 0 && steps.jira_keys.outputs.jira-keys != '' && always() }}
+  #       id: push_build_info_to_jira
+  #       uses: VirtoCommerce/jira-upload-build-info@master
+  #       with:
+  #         cloud-instance-base-url: '${{ secrets.CLOUD_INSTANCE_BASE_URL }}'
+  #         client-id: '${{ secrets.CLIENT_ID }}'
+  #         client-secret: '${{ secrets.CLIENT_SECRET }}'
+  #         pipeline-id: '${{ github.repository }} ${{ github.workflow }}'
+  #         build-number: ${{ github.run_number }}
+  #         build-display-name: 'Workflow: ${{ github.workflow }} (#${{ github.run_number }})'
+  #         build-state: '${{ env.BUILD_STATE }}'
+  #         build-url: '${{github.event.repository.url}}/actions/runs/${{github.run_id}}'
+  #         update-sequence-number: '${{ github.run_id }}'
+  #         last-updated: '${{github.event.head_commit.timestamp}}'
+  #         issue-keys: '${{ steps.jira_keys.outputs.jira-keys }}'
+  #         commit-id: '${{ github.sha }}'
+  #         repo-url: '${{ github.event.repository.url }}'
+  #         build-ref-url: '${{ github.event.repository.url }}/actions/runs/${{ github.run_id }}'
 
-      - name: Confirm Jira Build Output
-        if: success()
-        run: |
-          echo "Jira Upload Build Info response: ${{ steps.push_build_info_to_jira.outputs.response }}"
+  #     - name: Confirm Jira Build Output
+  #       if: success()
+  #       run: |
+  #         echo "Jira Upload Build Info response: ${{ steps.push_build_info_to_jira.outputs.response }}"
 
-      - name: Update Jira Tasks with Release Number
-        if: ${{ github.ref == 'refs/heads/master' }}
-        uses: VirtoCommerce/vc-github-actions/update-jira-tasks-with-release-number@master
-        with:
-          ghRepository: ${{ github.repository }}
-          ghReleaseTag: ${{ steps.image.outputs.prefix }}
-          jiraCustomFieldId: 'customfield_10297' # 'customfield_10297' corresponds to 'Theme release' field
-          jiraCustomFieldValue: "${{ steps.image.outputs.prefix }}"
-          client-id: '${{ secrets.JIRA_USER }}'
-          client-secret: '${{ secrets.JIRA_TOKEN }}'
+  #     - name: Update Jira Tasks with Release Number
+  #       if: ${{ github.ref == 'refs/heads/master' }}
+  #       uses: VirtoCommerce/vc-github-actions/update-jira-tasks-with-release-number@master
+  #       with:
+  #         ghRepository: ${{ github.repository }}
+  #         ghReleaseTag: ${{ steps.image.outputs.prefix }}
+  #         jiraCustomFieldId: 'customfield_10297' # 'customfield_10297' corresponds to 'Theme release' field
+  #         jiraCustomFieldValue: "${{ steps.image.outputs.prefix }}"
+  #         client-id: '${{ secrets.JIRA_USER }}'
+  #         client-secret: '${{ secrets.JIRA_TOKEN }}'
 
-      - name: Set branch name value
-        if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
-          (github.event_name == 'workflow_dispatch') || ((github.base_ref == 'dev') && (github.event_name == 'pull_request')) }}
-        id: branch_name
-        shell: pwsh
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          HEAD_REF: ${{ github.head_ref }}
-          REF_NAME: ${{ github.ref_name }}
-        run: |
-          if ($env:EVENT_NAME -eq 'pull_request'){
-            $branchName = $env:HEAD_REF
-          } else {
-            $branchName = $env:REF_NAME
-          }
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "branchName=$branchName"
+  #     - name: Set branch name value
+  #       if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
+  #         (github.event_name == 'workflow_dispatch') || ((github.base_ref == 'dev') && (github.event_name == 'pull_request')) }}
+  #       id: branch_name
+  #       shell: pwsh
+  #       env:
+  #         EVENT_NAME: ${{ github.event_name }}
+  #         HEAD_REF: ${{ github.head_ref }}
+  #         REF_NAME: ${{ github.ref_name }}
+  #       run: |
+  #         if ($env:EVENT_NAME -eq 'pull_request'){
+  #           $branchName = $env:HEAD_REF
+  #         } else {
+  #           $branchName = $env:REF_NAME
+  #         }
+  #         Add-Content -Path $env:GITHUB_OUTPUT -Value "branchName=$branchName"
 
-  ui-e2e-auto-tests:
-    needs: 'ci'
-    if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
-        (github.event_name == 'workflow_dispatch') || (github.base_ref == 'dev') && (github.event_name == 'pull_request') }}
-    uses: VirtoCommerce/.github/.github/workflows/e2e-autotests.yml@v3.800.23
-    with:
-      installModules: 'false'
-      installCustomModule: 'false'
-      runTests: 'true'
-      vctestingRepoBranch: 'dev'
-      frontendZipUrl: '${{ needs.ci.outputs.artifactUrl }}'
-      customPackagesJsonUrl: 'https://github.com/${{ github.repository }}/raw/${{ needs.ci.outputs.branchName }}/backend-packages.json'
-    secrets:
-      envPAT: ${{ secrets.REPO_TOKEN }}
-      testSecretEnvFile: ${{ secrets.VC_TESTING_MODULE_ENV_FILE }}
-      sendgridApiKey: ${{ secrets.SENDGRID_APIKEY_4E2E_AUTOTESTS }}
+  # ui-e2e-auto-tests:
+  #   needs: 'ci'
+  #   if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
+  #       (github.event_name == 'workflow_dispatch') || (github.base_ref == 'dev') && (github.event_name == 'pull_request') }}
+  #   uses: VirtoCommerce/.github/.github/workflows/e2e-autotests.yml@v3.800.23
+  #   with:
+  #     installModules: 'false'
+  #     installCustomModule: 'false'
+  #     runTests: 'true'
+  #     vctestingRepoBranch: 'dev'
+  #     frontendZipUrl: '${{ needs.ci.outputs.artifactUrl }}'
+  #     customPackagesJsonUrl: 'https://github.com/${{ github.repository }}/raw/${{ needs.ci.outputs.branchName }}/backend-packages.json'
+  #   secrets:
+  #     envPAT: ${{ secrets.REPO_TOKEN }}
+  #     testSecretEnvFile: ${{ secrets.VC_TESTING_MODULE_ENV_FILE }}
+  #     sendgridApiKey: ${{ secrets.SENDGRID_APIKEY_4E2E_AUTOTESTS }}
 
-  ui-auto-tests:
-    needs: 'ci'
-    if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
-      (github.base_ref == 'dev') && (github.event_name == 'pull_request') || 
-      (github.event_name == 'workflow_dispatch') }}
-    uses: VirtoCommerce/.github/.github/workflows/ui-autotests.yml@v3.800.23
-    with:
-      installModules: 'true'
-      installCustomModule: 'false'
-      platformDockerTag: 'linux-latest'
-      frontendZipUrl: '${{ needs.ci.outputs.artifactUrl }}'
-      vctestingRepoBranch: 'dev'
-    secrets:
-      envPAT: ${{ secrets.REPO_TOKEN }}
-      testSecretEnvFile: ${{ secrets.VC_TESTING_MODULE_ENV_FILE }}
-      sendgridApiKey: ${{ secrets.SENDGRID_APIKEY_4E2E_AUTOTESTS }}
+  # ui-auto-tests:
+  #   needs: 'ci'
+  #   if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
+  #     (github.base_ref == 'dev') && (github.event_name == 'pull_request') || 
+  #     (github.event_name == 'workflow_dispatch') }}
+  #   uses: VirtoCommerce/.github/.github/workflows/ui-autotests.yml@v3.800.23
+  #   with:
+  #     installModules: 'true'
+  #     installCustomModule: 'false'
+  #     platformDockerTag: 'linux-latest'
+  #     frontendZipUrl: '${{ needs.ci.outputs.artifactUrl }}'
+  #     vctestingRepoBranch: 'dev'
+  #   secrets:
+  #     envPAT: ${{ secrets.REPO_TOKEN }}
+  #     testSecretEnvFile: ${{ secrets.VC_TESTING_MODULE_ENV_FILE }}
+  #     sendgridApiKey: ${{ secrets.SENDGRID_APIKEY_4E2E_AUTOTESTS }}
 
   deploy-cloud:
-    if: ${{ github.ref == 'refs/heads/dev' || github.event_name == 'pull_request'}}
-    needs: ci
+    # if: ${{ github.ref == 'refs/heads/dev' || github.event_name == 'pull_request'}}
+    # needs: ci
     uses: ./.github/workflows/deploy-cloud.yml
     with:
       cmPath: 'theme/artifact.json'


### PR DESCRIPTION
## Description

## References
### Jira-link:
[<!-- Put link to your task in Jira here -->](https://virtocommerce.atlassian.net/browse/VCST-4746)
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.44.0-pr-2210-a85e-a85eb436.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies the deployment verification step in the GitHub Actions workflow, which can impact whether deployments are correctly validated and marked successful/failed. Relies on new inputs/secrets (`cloudUrl`, `VIRTOCLOUD_KEY`) and the `vc-build CloudEnvStatus` tool, so misconfiguration could break deploy runs.
> 
> **Overview**
> **Migrates cloud deployment health verification away from ArgoCD.** The `deploy-cloud.yml` workflow drops the `argoServer`/ArgoCD CLI wait and instead installs `VirtoCommerce.GlobalTool` and runs `vc-build CloudEnvStatus` to validate the environment is *Healthy* and *Synced*.
> 
> Adds a new `cloudUrl` input (for both `workflow_call` and `workflow_dispatch`) and wires it into `CLOUD_URL`, plus introduces `VIRTOCLOUD_KEY` (from secrets) for authenticating the new status check.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a85eb43636c4833ad5b952c95d92412d5cf0e728. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->