### PR TITLE
fix(VCST-4852): vc-select case-sensitive

### DIFF
--- a/client-app/ui-kit/components/molecules/select/vc-select.vue
+++ b/client-app/ui-kit/components/molecules/select/vc-select.vue
@@ -305,9 +305,18 @@ const filteredItems = computed(() => {
   }
 
   const searching = filterValue.value.toLowerCase();
-  const items = props.items.filter((item) => getItemText(item).toLowerCase().includes(searching));
+  const items = props.items.filter((item) =>
+    String(getItemText(item) ?? "")
+      .toLowerCase()
+      .includes(searching),
+  );
 
-  const first = items.filter((item) => getItemText(item).toLowerCase().indexOf(searching) === 0);
+  const first = items.filter(
+    (item) =>
+      String(getItemText(item) ?? "")
+        .toLowerCase()
+        .indexOf(searching) === 0,
+  );
 
   return union(first, items);
 });

--- a/client-app/ui-kit/components/molecules/select/vc-select.vue
+++ b/client-app/ui-kit/components/molecules/select/vc-select.vue
@@ -169,7 +169,7 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { union, lowerCase, isEqual } from "lodash";
+import { union, isEqual } from "lodash";
 import { computed, ref, useTemplateRef, provide, toRef, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { vcPopoverKey } from "@/ui-kit/components/atoms/popover/vc-popover-context";
@@ -304,10 +304,10 @@ const filteredItems = computed(() => {
     return props.items;
   }
 
-  const searching = lowerCase(filterValue.value);
-  const items = props.items.filter((item) => lowerCase(getItemText(item)).includes(searching));
+  const searching = filterValue.value.toLowerCase();
+  const items = props.items.filter((item) => getItemText(item).toLowerCase().includes(searching));
 
-  const first = items.filter((item) => lowerCase(getItemText(item)).indexOf(searching) === 0);
+  const first = items.filter((item) => getItemText(item).toLowerCase().indexOf(searching) === 0);
 
   return union(first, items);
 });


### PR DESCRIPTION
## Description

## References
### Jira-link:
<!-- Put link to your task in Jira here -->
https://virtocommerce.atlassian.net/browse/VCST-4852
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.45.0-pr-2232-3e4e-3e4eaf3f.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to client-side filtering logic; main risk is slight behavior differences in string normalization compared to lodash.
> 
> **Overview**
> Makes `vc-select` option filtering consistently *case-insensitive* by switching from lodash `lowerCase` to native `toLowerCase()` and normalizing item text via `String(getItemText(item) ?? "")`.
> 
> Also removes the unused lodash `lowerCase` import, keeping the existing “prefix matches first” ordering behavior intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e4eaf3f468f3e58ab7a4b22b62e96622018cc9f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->