### PR TITLE
fix(VCST-4816): xs size vc-badge vertical centering

### DIFF
--- a/client-app/ui-kit/components/atoms/badge/vc-badge.vue
+++ b/client-app/ui-kit/components/atoms/badge/vc-badge.vue
@@ -56,7 +56,7 @@ withDefaults(defineProps<IProps>(), {
       --vc-icon-size: 0.625rem;
       --gap: 0.25rem;
 
-      @apply px-[0.188rem] text-xxs/[1];
+      @apply pb-px px-[0.188rem] text-xxs/[1];
 
       &--dot {
         @apply size-1.5;


### PR DESCRIPTION
## Description
VcBadge XS size
<img width="64" height="57" alt="Screenshot 2026-04-06 at 16 05 07" src="https://github.com/user-attachments/assets/e9cbb8d1-2ebe-4396-b228-e809ddd5fd2d" />

## References
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4816
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.45.0-pr-2240-def0-def04a89.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, CSS-only change limited to the `xs` badge variant; potential impact is minor visual alignment differences in layouts using `vc-badge` size `xs`.
> 
> **Overview**
> Updates `vc-badge` styling for the `xs` size by adding a `pb-px` (1px bottom padding) Tailwind utility, adjusting vertical alignment/height of the smallest badge variant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit def04a897956ace2e5ab83a19bda6c2e11218083. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->