### PR TITLE
#4866 fix: sticky side bar wrong calculation of the offset value;

### DIFF
--- a/client-app/ui-kit/composables/useSmartSticky.ts
+++ b/client-app/ui-kit/composables/useSmartSticky.ts
@@ -167,6 +167,10 @@ function getAffixType(params: IAffixTypeParams): AffixType {
     return checkScrollingUp(elementTop, viewportTop, topSpacing, containerTop);
   }
 
+  if (viewportTop + topSpacing <= containerTop + POSITION_TOLERANCE) {
+    return AFFIX_TYPES.STATIC;
+  }
+
   return AFFIX_TYPES.ABSOLUTE;
 }
 
@@ -340,13 +344,6 @@ export function useSmartSticky(options: ISmartStickyOptions): IUseSmartStickyRet
       alignSelf: "flex-end",
     };
 
-    const absoluteStyle: CSSProperties = {
-      ...baseStyle,
-      position: "absolute",
-      top: `${translate.value}px`,
-      bottom: "auto",
-    };
-
     switch (affixType) {
       case AFFIX_TYPES.FIXED_TOP: {
         style.value = stickyTopStyle;
@@ -373,7 +370,14 @@ export function useSmartSticky(options: ISmartStickyOptions): IUseSmartStickyRet
       }
 
       case AFFIX_TYPES.ABSOLUTE: {
-        style.value = absoluteStyle;
+        translate.value = elementTop - containerTop;
+        style.value = {
+          ...baseStyle,
+          position: "absolute",
+          top: `${translate.value}px`,
+          bottom: "auto",
+        };
+
         break;
       }
     }
@@ -459,7 +463,6 @@ export function useSmartSticky(options: ISmartStickyOptions): IUseSmartStickyRet
   watch([elementBounding.height, containerBounding.height], updateImmediate);
 
   watch(isEnabled, (value) => {
-    // eslint-disable-next-line sonarjs/no-selector-parameter
     if (value) {
       void update();
     } else {


### PR DESCRIPTION
## Description
**What:**
Right sidebar renders in sticky mode immediately on load (anchored below nav header) instead of its natural inline position.

**Why:**
When summary widget items load asynchronously, the sidebar grows through multiple render passes. elementBounding.height updates before containerBounding.height (separate RAF callbacks), causing a transient STATIC_BOTTOM state that sets translate = containerHeight - elementHeight (negative, e.g. -674px). Next recalculation has no scroll direction - falls through to ABSOLUTE, which reused the stale negative translate via a pre-built absoluteStyle object, resulting in position: absolute; top: -674px.

**Fix:**
Return STATIC instead of ABSOLUTE when no scrolling has occurred and viewport hasn't passed the container top - prevents the cascade during initial render / content resize.
Recalculate translate from current element position inside the ABSOLUTE case instead of reusing a stale value captured before the switch.

## References
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4866
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.45.0-pr-2242-55b0-55b04f1e.zip