### PR TITLE
feat(VCST-4893): add support for payment localization

### DIFF
--- a/backend-packages.json
+++ b/backend-packages.json
@@ -165,7 +165,7 @@
         },
         {
           "Id": "VirtoCommerce.Payment",
-          "Version": "3.1001.0"
+          "Version": "3.1002.0"
         },
         {
           "Id": "VirtoCommerce.Sanity",
@@ -193,7 +193,7 @@
         },
         {
           "Id": "VirtoCommerce.XOrder",
-          "Version": "3.1001.0"
+          "Version": "3.1002.0"
         },
         {
           "Id": "VirtoCommerce.PriceExportImport",
@@ -273,7 +273,7 @@
         },
         {
           "Id": "VirtoCommerce.XCart",
-          "Version": "3.1005.0"
+          "Version": "3.1006.0"
         },
         {
           "Id": "VirtoCommerce.Cart",

--- a/client-app/core/api/graphql/payment/mutations/authorizePayment/index.ts
+++ b/client-app/core/api/graphql/payment/mutations/authorizePayment/index.ts
@@ -1,3 +1,4 @@
+import { globals } from "@/core/globals";
 import { graphqlClient } from "../../../client";
 import mutationDocument from "./authorizePaymentMutation.graphql";
 import type {
@@ -14,7 +15,11 @@ export async function authorizePayment(payload: InputAuthorizePaymentType): Prom
   >({
     mutation: mutationDocument,
     variables: {
-      command: payload,
+      command: {
+        storeId: globals.storeId,
+        cultureName: globals.cultureName,
+        ...payload,
+      },
     },
   });
 

--- a/client-app/core/api/graphql/payment/mutations/initializeCartPayment/index.ts
+++ b/client-app/core/api/graphql/payment/mutations/initializeCartPayment/index.ts
@@ -1,3 +1,4 @@
+import { globals } from "@/core/globals";
 import { graphqlClient } from "../../../client";
 import mutationDocument from "./initializeCartPaymentMutation.graphql";
 import type {
@@ -16,7 +17,11 @@ export async function initializeCartPayment(
   >({
     mutation: mutationDocument,
     variables: {
-      command: payload,
+      command: {
+        storeId: globals.storeId,
+        cultureName: globals.cultureName,
+        ...payload,
+      },
     },
   });
 

--- a/client-app/core/api/graphql/payment/mutations/initializePayment/index.ts
+++ b/client-app/core/api/graphql/payment/mutations/initializePayment/index.ts
@@ -1,3 +1,4 @@
+import { globals } from "@/core/globals";
 import { graphqlClient } from "../../../client";
 import mutationDocument from "./initializePaymentMutation.graphql";
 import type {
@@ -14,7 +15,11 @@ export async function initializePayment(payload: InputInitializePaymentType): Pr
   >({
     mutation: mutationDocument,
     variables: {
-      command: payload,
+      command: {
+        storeId: globals.storeId,
+        cultureName: globals.cultureName,
+        ...payload,
+      },
     },
   });
 

--- a/client-app/core/api/graphql/types.ts
+++ b/client-app/core/api/graphql/types.ts
@@ -1706,12 +1706,16 @@ export type InputAssignRoleType = {
 };
 
 export type InputAuthorizePaymentType = {
+  /** Culture name (e.g. "en-US"); when omitted falls back to store default language */
+  cultureName?: InputMaybe<Scalars['String']['input']>;
   /** Order Id */
   orderId?: InputMaybe<Scalars['String']['input']>;
   /** Input parameters */
   parameters?: InputMaybe<Array<InputMaybe<InputKeyValueType>>>;
   /** Payment Id */
   paymentId: Scalars['String']['input'];
+  /** Store Id (optional, validated against the order's store when provided) */
+  storeId?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type InputCartItemQuantityType = {
@@ -2102,17 +2106,25 @@ export type InputDynamicPropertyValueType = {
 
 export type InputInitializeCartPaymentType = {
   cartId: Scalars['String']['input'];
+  /** Culture name (e.g. "en-US"); when omitted falls back to store default language */
+  cultureName?: InputMaybe<Scalars['String']['input']>;
   /** Payment Id */
   paymentId: Scalars['String']['input'];
+  /** Store Id (optional, validated against the cart's store when provided) */
+  storeId?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type InputInitializePaymentType = {
+  /** Culture name (e.g. "en-US"); when omitted falls back to store default language */
+  cultureName?: InputMaybe<Scalars['String']['input']>;
   /** Order Id */
   orderId?: InputMaybe<Scalars['String']['input']>;
   /** Input parameters */
   parameters?: InputMaybe<Array<InputMaybe<InputKeyValueType>>>;
   /** Payment Id */
   paymentId: Scalars['String']['input'];
+  /** Store Id (optional, validated against the order's store when provided) */
+  storeId?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type InputInviteUserType = {

--- a/client-app/pages/account/order-payment.vue
+++ b/client-app/pages/account/order-payment.vue
@@ -144,16 +144,10 @@
                 </p>
 
                 <p class="truncate">
-                  <span class="font-bold">
-                    {{ $t("pages.account.order_payment.phone_label") }}
-                  </span>
                   {{ payment?.billingAddress?.phone }}
                 </p>
 
                 <p class="truncate">
-                  <span class="font-bold">
-                    {{ $t("pages.account.order_payment.email_label") }}
-                  </span>
                   {{ payment?.billingAddress?.email }}
                 </p>
               </div>


### PR DESCRIPTION
## Description
Add support for payment localization.

## References
### Jira-link:
<!-- Put link to your task in Jira here -->
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.46.0-pr-2256-49dd-49ddfe2d.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates payment mutation inputs and client calls to always include `storeId`/`cultureName`, which can affect payment initialization/authorization behavior across stores/locales. Also bumps backend module versions, so runtime behavior depends on updated server packages.
> 
> **Overview**
> Adds payment-localization support by extending GraphQL payment mutation inputs (`InputAuthorizePaymentType`, `InputInitializePaymentType`, `InputInitializeCartPaymentType`) with optional `storeId` and `cultureName`, and updating the corresponding client mutations to inject `globals.storeId`/`globals.cultureName` into the `command` variables.
> 
> Updates backend package manifest versions for `VirtoCommerce.Payment`, `VirtoCommerce.XOrder`, and `VirtoCommerce.XCart`, and makes a small UI tweak on `order-payment.vue` by removing the phone/email label prefixes in the billing address display.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49ddfe2d5577ee6b795307e022169bbc03cf6f10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->