### PR TITLE
fix(VCST-4909): sort sidebar categories alphabetically

### DIFF
--- a/client-app/shared/catalog/components/category-selector.vue
+++ b/client-app/shared/catalog/components/category-selector.vue
@@ -84,12 +84,14 @@ const { objectType, seoInfo } = useSlugInfo(route.path.slice(1));
 const parentCategory = computed<CategoryType | undefined>(() => props.category?.parent);
 const subcategories = computed<CategoryType[]>(
   () =>
-    props.category?.childCategories.map((el) => {
-      return {
-        ...el,
-        facet: getFacet(el),
-      };
-    }) || [],
+    props.category?.childCategories
+      .map((el) => {
+        return {
+          ...el,
+          facet: getFacet(el),
+        };
+      })
+      .sort((a, b) => a.name.localeCompare(b.name)) || [],
 );
 
 const searchParam = useRouteQueryParam<string>(QueryParamName.SearchPhrase);


### PR DESCRIPTION
## Description

## References
### Jira-link:
<!-- Put link to your task in Jira here -->
https://virtocommerce.atlassian.net/browse/VCST-4909
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.46.0-pr-2258-fa4d-fa4de9db.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change: adjusts client-side ordering of displayed subcategories without affecting routing, query params, or backend data.
> 
> **Overview**
> **Sidebar subcategories are now displayed in alphabetical order.**
> 
> In `category-selector.vue`, the computed `subcategories` list is now sorted by `name` (`localeCompare`) after facet enrichment, ensuring consistent ordering in the category navigation widget.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa4de9dbc1162189b7f32d4e524b268fe63f835f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->