### PR TITLE
VCST-4770: Update Node in actions

### DIFF
--- a/.github/workflows/storybook-ci.yml
+++ b/.github/workflows/storybook-ci.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
 
       - name: Set up Node 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
 
@@ -54,7 +54,7 @@ jobs:
         run: |
           echo "RELEASE_STATUS=true" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/theme-ci.yml
+++ b/.github/workflows/theme-ci.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
 
       - name: Set up Node 22
-        uses: actions/setup-node@v4.2.0
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
 
@@ -56,7 +56,7 @@ jobs:
         run: |
           echo "RELEASE_STATUS=true" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -120,7 +120,7 @@ jobs:
           yarn test:coverage
 
       - name: Upload Coverage Report
-        uses:  actions/upload-artifact@v4
+        uses:  actions/upload-artifact@v7
         with:
           name: coverage-report
           path: coverage
@@ -252,7 +252,7 @@ jobs:
     needs: 'ci'
     if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
         (github.event_name == 'workflow_dispatch') || (github.base_ref == 'dev') && (github.event_name == 'pull_request') }}
-    uses: VirtoCommerce/.github/.github/workflows/e2e-autotests.yml@v3.800.23
+    uses: VirtoCommerce/.github/.github/workflows/e2e-autotests.yml@VCST-4770 #v3.800.23
     with:
       installModules: 'false'
       installCustomModule: 'false'
@@ -270,7 +270,7 @@ jobs:
     if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
       (github.base_ref == 'dev') && (github.event_name == 'pull_request') || 
       (github.event_name == 'workflow_dispatch') }}
-    uses: VirtoCommerce/.github/.github/workflows/ui-autotests.yml@v3.800.23
+    uses: VirtoCommerce/.github/.github/workflows/ui-autotests.yml@VCST-4770 #v3.800.23
     with:
       installModules: 'true'
       installCustomModule: 'false'

--- a/.github/workflows/theme-ci.yml
+++ b/.github/workflows/theme-ci.yml
@@ -97,7 +97,7 @@ jobs:
           yarn install
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@v5.3.1
+        uses: SonarSource/sonarqube-scan-action@v7.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/theme-ci.yml
+++ b/.github/workflows/theme-ci.yml
@@ -252,7 +252,7 @@ jobs:
     needs: 'ci'
     if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
         (github.event_name == 'workflow_dispatch') || (github.base_ref == 'dev') && (github.event_name == 'pull_request') }}
-    uses: VirtoCommerce/.github/.github/workflows/e2e-autotests.yml@VCST-4770 #v3.800.23
+    uses: VirtoCommerce/.github/.github/workflows/e2e-autotests.yml@v3.800.29
     with:
       installModules: 'false'
       installCustomModule: 'false'
@@ -270,7 +270,7 @@ jobs:
     if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
       (github.base_ref == 'dev') && (github.event_name == 'pull_request') || 
       (github.event_name == 'workflow_dispatch') }}
-    uses: VirtoCommerce/.github/.github/workflows/ui-autotests.yml@VCST-4770 #v3.800.23
+    uses: VirtoCommerce/.github/.github/workflows/ui-autotests.yml@v3.800.29
     with:
       installModules: 'true'
       installCustomModule: 'false'

--- a/.github/workflows/theme-release-hotfix.yml
+++ b/.github/workflows/theme-release-hotfix.yml
@@ -12,12 +12,12 @@ jobs:
       VERSION_SUFFIX: ""
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Node 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
 


### PR DESCRIPTION
## Description

## References
### Jira-link:
(https://virtocommerce.atlassian.net/browse/VCST-4770)
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.46.0-pr-2260-6f20-6f204701.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates multiple GitHub Actions and reusable workflow versions, which can change CI behavior and potentially break builds or reporting despite no product code changes.
> 
> **Overview**
> Updates CI workflows to newer GitHub Actions versions: `actions/setup-node` to `v6` and `actions/checkout` to `v6` across Storybook, theme CI, and hotfix release pipelines.
> 
> Refreshes tooling used in CI by bumping `SonarSource/sonarqube-scan-action` to `v7.1.0`, `actions/upload-artifact` to `v7`, and updating the referenced VirtoCommerce UI/e2e autotest reusable workflows from `v3.800.23` to `v3.800.29`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f2047011d17520410d98c7ae71a33410fe781f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->