### PR TITLE
feat(VCST-4928): add character counter to configurable product text section input

### DIFF
--- a/client-app/shared/catalog/components/configuration/section-text-fieldset.vue
+++ b/client-app/shared/catalog/components/configuration/section-text-fieldset.vue
@@ -17,6 +17,7 @@
       <VcInput
         v-model="customInput"
         :maxlength="MAX_LENGTH"
+        counter
         class="section-text-fieldset__input"
         :aria-label="$t(constructLocaleKey('enter_custom_text'))"
         data-test-id="custom-input"

--- a/client-app/ui-kit/components/atoms/input-details/vc-input-details.vue
+++ b/client-app/ui-kit/components/atoms/input-details/vc-input-details.vue
@@ -27,13 +27,25 @@
     </template>
 
     <!-- Counter -->
-    <div v-if="counter" class="vc-input-details__counter">
+    <div
+      v-if="counter"
+      :class="[
+        'vc-input-details__counter',
+        {
+          'vc-input-details__counter--limit': isAtLimit,
+        },
+      ]"
+      :role="isAtLimit ? 'status' : undefined"
+      :aria-live="isAtLimit ? 'polite' : undefined"
+    >
       {{ textLength }}<template v-if="maxLength"> / {{ maxLength }}</template>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
+import { computed } from "vue";
+
 interface IProps {
   id?: string;
   message?: string;
@@ -45,8 +57,15 @@ interface IProps {
   maxLength?: number | string;
 }
 
-withDefaults(defineProps<IProps>(), {
+const props = withDefaults(defineProps<IProps>(), {
   textLength: 0,
+});
+
+const isAtLimit = computed(() => {
+  if (!props.maxLength) {
+    return false;
+  }
+  return props.textLength >= Number(props.maxLength);
 });
 </script>
 
@@ -83,6 +102,10 @@ withDefaults(defineProps<IProps>(), {
 
   &__counter {
     @apply ms-auto text-right whitespace-nowrap;
+
+    &--limit {
+      @apply text-danger;
+    }
   }
 }
 </style>

--- a/client-app/ui-kit/components/atoms/input-details/vc-input-details.vue
+++ b/client-app/ui-kit/components/atoms/input-details/vc-input-details.vue
@@ -82,7 +82,7 @@ withDefaults(defineProps<IProps>(), {
   }
 
   &__counter {
-    @apply text-right whitespace-nowrap;
+    @apply ms-auto text-right whitespace-nowrap;
   }
 }
 </style>

--- a/client-app/ui-kit/components/molecules/input/vc-input.stories.ts
+++ b/client-app/ui-kit/components/molecules/input/vc-input.stories.ts
@@ -34,6 +34,10 @@ const meta: Meta = {
     step: { table: { type: { summary: "string|number" } } },
     minlength: { table: { type: { summary: "string|number" } } },
     maxlength: { table: { type: { summary: "string|number" } } },
+    counter: {
+      control: "boolean",
+      description: "Shows a character counter below the input",
+    },
     modelValue: { table: { type: { summary: "string|number" } } },
   },
   args: {
@@ -44,6 +48,7 @@ const meta: Meta = {
     center: false,
     hidePasswordSwitcher: false,
     error: false,
+    counter: false,
     showEmptyDetails: false,
     type: "text",
     size: "md",
@@ -129,4 +134,35 @@ export const WithButton: StoryType = {
       </template>
     </VcInput>`,
   }),
+};
+
+export const WithCounter: StoryType = {
+  args: {
+    label: "Label",
+    placeholder: "Placeholder",
+    counter: true,
+    maxlength: 30,
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `<VcInput label="Label" counter :maxlength="30" />`,
+      },
+    },
+  },
+};
+
+export const WithMessageAndCounter: StoryType = {
+  args: {
+    ...commonArgs,
+    counter: true,
+    maxlength: 30,
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `<VcInput label="Label" message="Hint message" counter :maxlength="30" />`,
+      },
+    },
+  },
 };

--- a/client-app/ui-kit/components/molecules/input/vc-input.vue
+++ b/client-app/ui-kit/components/molecules/input/vc-input.vue
@@ -84,7 +84,15 @@
       </div>
     </div>
 
-    <VcInputDetails :show-empty="showEmptyDetails" :message="message" :error="error" :single-line="singleLineMessage" />
+    <VcInputDetails
+      :show-empty="showEmptyDetails"
+      :counter="counter"
+      :message="message"
+      :error="error"
+      :text-length="textLength"
+      :max-length="maxlength"
+      :single-line="singleLineMessage"
+    />
   </div>
 </template>
 
@@ -110,6 +118,7 @@ export interface IProps {
   noBorder?: boolean;
   hidePasswordSwitcher?: boolean;
   showEmptyDetails?: boolean;
+  counter?: boolean;
   min?: string | number;
   max?: string | number;
   step?: string | number;
@@ -174,6 +183,8 @@ const model = defineModel<T>({
     return !(props.type === "number" && value === "") ? value : undefined;
   },
 });
+
+const textLength = computed(() => String(model.value ?? "").length);
 
 const _size = computed(() => props.size);
 

--- a/client-app/ui-kit/components/molecules/input/vc-input.vue
+++ b/client-app/ui-kit/components/molecules/input/vc-input.vue
@@ -41,6 +41,7 @@
         :step="stepValue"
         :autocomplete="computedAutocomplete"
         :aria-label="ariaLabel ?? label"
+        :aria-describedby="counter || message ? detailsId : undefined"
         :title="browserTooltip === 'enabled' ? message : ''"
         class="vc-input__input"
         :tabindex="tabindex"
@@ -85,6 +86,7 @@
     </div>
 
     <VcInputDetails
+      :id="counter || message ? detailsId : undefined"
       :show-empty="showEmptyDetails"
       :counter="counter"
       :message="message"
@@ -158,6 +160,7 @@ const props = withDefaults(defineProps<IProps>(), {
 const LIMITED_TYPES: IProps["type"][] = ["number", "date"];
 
 const componentId = useComponentId("input");
+const detailsId = componentId + "-details";
 const listeners = useListeners();
 const attrs = useAttrsOnly();
 


### PR DESCRIPTION
## Description

<img width="1061" height="193" alt="Screenshot 2026-04-16 at 14 34 21" src="https://github.com/user-attachments/assets/e11424c4-b717-410f-b671-20c17ee54cd5" />
<img width="310" height="200" alt="Screenshot 2026-04-16 at 14 34 39" src="https://github.com/user-attachments/assets/d751f762-24f4-4ffa-9e4a-a393fbfb6491" />
<img width="313" height="330" alt="Screenshot 2026-04-16 at 14 52 21" src="https://github.com/user-attachments/assets/9d2c82c2-19f9-4280-98be-d5b9e6185eef" />

## References
### Jira-link:
<!-- Put link to your task in Jira here -->
https://virtocommerce.atlassian.net/browse/VCST-4928
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.47.0-pr-2263-2bf2-2bf2be51.zip


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change scoped to input rendering/accessibility; low risk aside from potential minor layout/ARIA behavior regressions in `VcInput` consumers.
> 
> **Overview**
> Adds a `counter` prop to `VcInput` that renders a live character count (and optional `maxLength`) via `VcInputDetails`, including `aria-describedby` wiring for accessibility.
> 
> Enhances the counter display to visually highlight when the max length is reached and announces the limit state (`role=status`/`aria-live`). The configurable product text section now enables this counter for the custom text input, and Storybook includes new counter examples.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bf2be511f3e062a334925afe7fa304c2992878a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->