### PR TITLE
feat: update date selector

### DIFF
--- a/client-app/ui-kit/components/molecules/date-selector/vc-date-selector.stories.ts
+++ b/client-app/ui-kit/components/molecules/date-selector/vc-date-selector.stories.ts
@@ -200,3 +200,58 @@ export const WithDateTime: StoryType = {
     },
   },
 };
+
+export const EventsDemo: StoryType = {
+  args: (() => {
+    const today = new Date().toISOString().split("T")[0];
+    const currentYear = new Date().getFullYear();
+
+    return {
+      modelValue: today,
+      min: `${currentYear}-01-01`,
+      max: `${currentYear}-12-31`,
+    };
+  })(),
+  render: (args) => ({
+    setup() {
+      return { args };
+    },
+    template: `
+    <div class="w-96 space-y-4">
+      <VcDateSelector
+        v-bind="args"
+        v-model="args.modelValue"
+        @input="onInput"
+        @change="onChange"
+        @blur="onBlur"
+      />
+      <div class="text-sm space-y-1">
+        <div class="font-bold">Last events:</div>
+        <pre class="bg-neutral-100 p-2 rounded text-xs overflow-auto max-h-48">{{ log }}</pre>
+      </div>
+    </div>
+  `,
+    data() {
+      return { log: "" };
+    },
+    methods: {
+      onInput(e: VcDateSelectorEventType) {
+        this.log = `@input: ${JSON.stringify(e, null, 2)}\n\n${this.log}`.slice(0, 2000);
+      },
+      onChange(e: VcDateSelectorEventType) {
+        this.log = `@change: ${JSON.stringify(e, null, 2)}\n\n${this.log}`.slice(0, 2000);
+      },
+      onBlur(e: VcDateSelectorEventType) {
+        this.log = `@blur: ${JSON.stringify(e, null, 2)}\n\n${this.log}`.slice(0, 2000);
+      },
+    },
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Interactive demo showing @input (every keystroke), @change (meaningful transitions), and @blur events with structured VcDateSelectorEventType payload. Edit the date to see events fire in real time.",
+      },
+    },
+  },
+};

--- a/client-app/ui-kit/components/molecules/date-selector/vc-date-selector.test.ts
+++ b/client-app/ui-kit/components/molecules/date-selector/vc-date-selector.test.ts
@@ -1,0 +1,209 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+import { createWrapperFactory } from "@/core/utilities/tests";
+import { VcButton, VcInput } from "@/ui-kit/components/molecules";
+import VcDateSelector from "./vc-date-selector.vue";
+
+const createWrapper = createWrapperFactory(mount, VcDateSelector, {
+  global: {
+    components: { VcInput, VcButton },
+    stubs: {
+      VcLabel: true,
+      VcIcon: true,
+      VcInputDetails: true,
+    },
+  },
+});
+
+function getInput(wrapper: ReturnType<typeof createWrapper>): HTMLInputElement {
+  return wrapper.find("input[type='date']").element as HTMLInputElement;
+}
+
+async function triggerNativeInput(wrapper: ReturnType<typeof createWrapper>, value: string) {
+  const input = getInput(wrapper);
+  // Simulate native value change + input event (mirrors browser segment editing)
+  Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!.call(input, value);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+  await wrapper.vm.$nextTick();
+}
+
+describe("VcDateSelector", () => {
+  describe("@input event", () => {
+    it("emits input event on native input with complete date", async () => {
+      const wrapper = createWrapper();
+      await triggerNativeInput(wrapper, "2026-04-16");
+
+      const events = wrapper.emitted("input") as VcDateSelectorEventType[][];
+      expect(events).toHaveLength(1);
+      expect(events[0][0]).toEqual({
+        value: "2026-04-16",
+        complete: true,
+        valid: true,
+        eventSource: "input",
+      });
+    });
+
+    it("emits input event with complete: false for empty value", async () => {
+      const wrapper = createWrapper();
+      await triggerNativeInput(wrapper, "");
+
+      const events = wrapper.emitted("input") as VcDateSelectorEventType[][];
+      expect(events).toHaveLength(1);
+      expect(events[0][0]).toEqual({
+        value: "",
+        complete: false,
+        valid: false,
+        eventSource: "input",
+      });
+    });
+
+    it("emits input event with valid: false when date is below min", async () => {
+      const wrapper = createWrapper({
+        props: { min: "2026-06-01" },
+      });
+      await triggerNativeInput(wrapper, "2026-04-16");
+
+      const events = wrapper.emitted("input") as VcDateSelectorEventType[][];
+      expect(events[0][0]).toMatchObject({
+        complete: true,
+        valid: false,
+      });
+    });
+
+    it("emits input event with valid: false when date is above max", async () => {
+      const wrapper = createWrapper({
+        props: { max: "2026-03-01" },
+      });
+      await triggerNativeInput(wrapper, "2026-04-16");
+
+      const events = wrapper.emitted("input") as VcDateSelectorEventType[][];
+      expect(events[0][0]).toMatchObject({
+        complete: true,
+        valid: false,
+      });
+    });
+  });
+
+  describe("@change event", () => {
+    it("emits change when date becomes complete (incomplete -> complete)", async () => {
+      const wrapper = createWrapper();
+      // First input: incomplete (no change expected)
+      await triggerNativeInput(wrapper, "");
+      expect(wrapper.emitted("change")).toBeUndefined();
+
+      // Second input: complete date
+      await triggerNativeInput(wrapper, "2026-04-16");
+      const events = wrapper.emitted("change") as VcDateSelectorEventType[][];
+      expect(events).toHaveLength(1);
+      expect(events[0][0]).toEqual({
+        value: "2026-04-16",
+        complete: true,
+        valid: true,
+        eventSource: "input",
+      });
+    });
+
+    it("emits change when complete date changes to another complete date", async () => {
+      const wrapper = createWrapper({ props: { modelValue: "2026-04-16" } });
+
+      await triggerNativeInput(wrapper, "2026-05-01");
+
+      const events = wrapper.emitted("change") as VcDateSelectorEventType[][];
+      expect(events).toHaveLength(1);
+      expect(events[0][0]).toMatchObject({
+        value: "2026-05-01",
+        complete: true,
+      });
+    });
+
+    it("emits change when complete date is cleared (complete -> incomplete)", async () => {
+      const wrapper = createWrapper({ props: { modelValue: "2026-04-16" } });
+
+      await triggerNativeInput(wrapper, "");
+
+      const events = wrapper.emitted("change") as VcDateSelectorEventType[][];
+      expect(events).toHaveLength(1);
+      expect(events[0][0]).toEqual({
+        value: "",
+        complete: false,
+        valid: false,
+        eventSource: "input",
+      });
+    });
+
+    it("does not emit change for incomplete -> incomplete", async () => {
+      const wrapper = createWrapper();
+      await triggerNativeInput(wrapper, "");
+      await triggerNativeInput(wrapper, "");
+
+      expect(wrapper.emitted("change")).toBeUndefined();
+    });
+
+    it("does not emit change when complete date stays the same", async () => {
+      const wrapper = createWrapper({ props: { modelValue: "2026-04-16" } });
+
+      await triggerNativeInput(wrapper, "2026-04-16");
+
+      expect(wrapper.emitted("change")).toBeUndefined();
+    });
+  });
+
+  describe("@blur event", () => {
+    it("emits blur with current state when input loses focus", async () => {
+      const wrapper = createWrapper({ props: { modelValue: "2026-04-16" } });
+      const input = wrapper.find("input[type='date']");
+
+      await input.trigger("blur");
+
+      const events = wrapper.emitted("blur") as VcDateSelectorEventType[][];
+      expect(events).toHaveLength(1);
+      expect(events[0][0]).toEqual({
+        value: "2026-04-16",
+        complete: true,
+        valid: true,
+        eventSource: "blur",
+      });
+    });
+  });
+
+  describe("eventSource: picker", () => {
+    it("emits change with eventSource 'picker' when calendar button triggers selection", async () => {
+      const wrapper = createWrapper();
+
+      // Simulate: calendar button clicked -> openCalendar sets pickerOpen flag
+      // Then native input fires (as if user selected from picker)
+      const calendarButton = wrapper.find("button");
+      await calendarButton.trigger("click");
+
+      // Simulate picker selection arriving as native input event
+      await triggerNativeInput(wrapper, "2026-04-16");
+
+      const events = wrapper.emitted("change") as VcDateSelectorEventType[][];
+      expect(events).toHaveLength(1);
+      expect(events[0][0]).toMatchObject({
+        eventSource: "picker",
+      });
+    });
+
+    it("resets eventSource to 'input' after keydown following cancelled picker", async () => {
+      const wrapper = createWrapper();
+      const input = wrapper.find("input[type='date']");
+
+      // Open picker
+      const calendarButton = wrapper.find("button");
+      await calendarButton.trigger("click");
+
+      // User cancels picker and starts typing (keydown resets flag)
+      await input.trigger("keydown");
+
+      // Keyboard input arrives
+      await triggerNativeInput(wrapper, "2026-04-16");
+
+      const events = wrapper.emitted("change") as VcDateSelectorEventType[][];
+      expect(events).toHaveLength(1);
+      expect(events[0][0]).toMatchObject({
+        eventSource: "input",
+      });
+    });
+  });
+});

--- a/client-app/ui-kit/components/molecules/date-selector/vc-date-selector.types.d.ts
+++ b/client-app/ui-kit/components/molecules/date-selector/vc-date-selector.types.d.ts
@@ -1,0 +1,16 @@
+declare global {
+  type VcDateSelectorEventSourceType = "input" | "picker" | "blur";
+
+  type VcDateSelectorEventType = {
+    /** Date value in YYYY-MM-DD format, or empty string when incomplete */
+    value: string;
+    /** True when all date segments are filled (value !== "") */
+    complete: boolean;
+    /** True when complete AND within min/max bounds */
+    valid: boolean;
+    /** What triggered this event */
+    eventSource: VcDateSelectorEventSourceType;
+  };
+}
+
+export {};

--- a/client-app/ui-kit/components/molecules/date-selector/vc-date-selector.vue
+++ b/client-app/ui-kit/components/molecules/date-selector/vc-date-selector.vue
@@ -155,20 +155,15 @@ function buildPayload(eventSource: VcDateSelectorEventSourceType): VcDateSelecto
   return { value, complete, valid, eventSource };
 }
 
-/**
- * Guard against duplicate native "input" events caused by the maska input-mask library,
- * which re-dispatches a synthetic "input" event after processing the original one.
- */
-let inputGuard = false;
-
-function onNativeInput(): void {
-  if (inputGuard) {
+function onNativeInput(event: Event): void {
+  /**
+   * VcInput applies the `v-maska` directive unconditionally. Even when no mask
+   * is passed, maska installs an input listener and re-dispatches a synthetic
+   * `CustomEvent("input")` after processing. Skip those to avoid double firing.
+   */
+  if (event instanceof CustomEvent) {
     return;
   }
-  inputGuard = true;
-  queueMicrotask(() => {
-    inputGuard = false;
-  });
 
   const source: VcDateSelectorEventSourceType = pickerOpen ? "picker" : "input";
   pickerOpen = false;

--- a/client-app/ui-kit/components/molecules/date-selector/vc-date-selector.vue
+++ b/client-app/ui-kit/components/molecules/date-selector/vc-date-selector.vue
@@ -1,6 +1,8 @@
 <template>
   <VcInput
-    v-model="dateOnly"
+    ref="vcInputRef"
+    :model-value="dateOnly"
+    v-bind="$attrs"
     :label="label"
     :name="name"
     type="date"
@@ -26,13 +28,15 @@
 </template>
 
 <script setup lang="ts">
-import { useVModel } from "@vueuse/core";
-import { computed, getCurrentInstance } from "vue";
+import { computed, getCurrentInstance, onBeforeUnmount, onMounted, ref, useTemplateRef, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { toDateOnlyString } from "@/ui-kit/utilities/date";
 
 interface IEmits {
   (e: "update:modelValue", value: string | undefined): void;
+  (e: "input", payload: VcDateSelectorEventType): void;
+  (e: "change", payload: VcDateSelectorEventType): void;
+  (e: "blur", payload: VcDateSelectorEventType): void;
 }
 
 interface IProps {
@@ -57,11 +61,31 @@ interface IProps {
   max?: string;
 }
 
+defineOptions({
+  inheritAttrs: false,
+});
+
 const emit = defineEmits<IEmits>();
 const props = defineProps<IProps>();
 
 const { t } = useI18n();
-const dateOnly = useVModel(props, "modelValue", emit);
+
+/**
+ * One-way binding to prevent v-model from writing "" back to the native date input
+ * during mid-edit (e.g., typing "0" in the day segment makes value="" temporarily).
+ * Writing "" back destroys Chrome's internal segment state (month/year get wiped).
+ * We only propagate complete values; on blur we commit whatever the final state is.
+ */
+const dateOnly = ref<string | undefined>();
+
+// Initialize and sync from external (programmatic) prop changes
+watch(
+  () => props.modelValue,
+  (val) => {
+    dateOnly.value = val;
+  },
+  { immediate: true },
+);
 
 const requiredComputed = computed(() => props.required ?? props.isRequired);
 const disabledComputed = computed(() => props.disabled ?? props.isDisabled);
@@ -69,20 +93,31 @@ const disabledComputed = computed(() => props.disabled ?? props.isDisabled);
 const normalizedMin = computed(() => toDateOnlyString(props.min));
 const normalizedMax = computed(() => toDateOnlyString(props.max));
 
-/**
- * Safari and Firefox don't enforce min/max validation on manual date input.
- * This provides consistent cross-browser validation.
- */
+// --- Validation (shared between computedErrorMessage and event payload) ---
+
+function isWithinMinMax(value: string): boolean {
+  if (!value) {
+    return false;
+  }
+  if (normalizedMin.value && value < normalizedMin.value) {
+    return false;
+  }
+  if (normalizedMax.value && value > normalizedMax.value) {
+    return false;
+  }
+  return true;
+}
+
 const computedErrorMessage = computed(() => {
   if (props.errorMessage) {
     return props.errorMessage;
   }
 
-  if (!dateOnly.value || (!normalizedMin.value && !normalizedMax.value)) {
+  if (!props.modelValue || (!normalizedMin.value && !normalizedMax.value)) {
     return undefined;
   }
 
-  const selectedDate = dateOnly.value;
+  const selectedDate = props.modelValue;
 
   if (normalizedMin.value && selectedDate < normalizedMin.value) {
     return t("ui_kit.date_selector.min_date_error", { min: normalizedMin.value });
@@ -94,6 +129,157 @@ const computedErrorMessage = computed(() => {
 
   return undefined;
 });
+
+// --- Event infrastructure ---
+
+const vcInputRef = useTemplateRef("vcInputRef");
+
+let pickerOpen = false;
+let lastCompleteValue: string | null = null;
+
+// Initialize lastCompleteValue from modelValue prop
+watch(
+  () => props.modelValue,
+  (val) => {
+    lastCompleteValue = val || null;
+  },
+  { immediate: true },
+);
+
+function buildPayload(eventSource: VcDateSelectorEventSourceType): VcDateSelectorEventType {
+  const inputEl = vcInputRef.value?.inputElement;
+  const value = inputEl?.value ?? "";
+  const complete = value !== "";
+  const valid = complete && isWithinMinMax(value);
+
+  return { value, complete, valid, eventSource };
+}
+
+/**
+ * Guard against duplicate native "input" events caused by the maska input-mask library,
+ * which re-dispatches a synthetic "input" event after processing the original one.
+ */
+let inputGuard = false;
+
+function onNativeInput(): void {
+  if (inputGuard) {
+    return;
+  }
+  inputGuard = true;
+  queueMicrotask(() => {
+    inputGuard = false;
+  });
+
+  const source: VcDateSelectorEventSourceType = pickerOpen ? "picker" : "input";
+  pickerOpen = false;
+
+  const payload = buildPayload(source);
+  emit("input", payload);
+
+  // Only propagate complete values to v-model to prevent
+  // Chrome from losing segment state during mid-edit
+  if (payload.complete) {
+    dateOnly.value = payload.value;
+    emit("update:modelValue", payload.value);
+  }
+
+  // @change: fire on meaningful transitions
+  const currentValue = payload.value;
+  const wasComplete = lastCompleteValue !== null;
+  const isComplete = payload.complete;
+
+  const shouldEmitChange =
+    // incomplete -> complete
+    (!wasComplete && isComplete) ||
+    // complete -> different complete
+    (wasComplete && isComplete && currentValue !== lastCompleteValue) ||
+    // complete -> incomplete
+    (wasComplete && !isComplete);
+
+  if (shouldEmitChange) {
+    emit("change", payload);
+  }
+
+  lastCompleteValue = isComplete ? currentValue : null;
+}
+
+function onNativeKeydown(): void {
+  pickerOpen = false;
+}
+
+function onNativeBlur(): void {
+  pickerOpen = false;
+  const payload = buildPayload("blur");
+
+  // On blur, commit current state to v-model (including empty when user cleared)
+  if (!payload.complete && dateOnly.value) {
+    dateOnly.value = undefined;
+    emit("update:modelValue", undefined);
+  }
+
+  emit("blur", payload);
+}
+
+/**
+ * Prevent Vue's v-model (inside VcInput) from writing "" back to the native date input
+ * during mid-edit. When a user types "0" in the day segment, Chrome returns value=""
+ * but preserves internal segment state (month/year). Vue's v-model writes "" back,
+ * which destroys that state. We intercept the value setter to block empty writes
+ * while the input is focused and has a known good value.
+ */
+const originalValueSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!;
+const originalValueGetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.get!;
+
+function installValueGuard(inputEl: HTMLInputElement): void {
+  Object.defineProperty(inputEl, "value", {
+    get() {
+      return originalValueGetter.call(this) as string;
+    },
+    set(val: string) {
+      // Block programmatic empty writes while focused and previously had a value.
+      // This lets Chrome keep its internal segment state intact during mid-edit.
+      if (val === "" && document.activeElement === this && dateOnly.value) {
+        return;
+      }
+      originalValueSetter.call(this, val);
+    },
+    configurable: true,
+  });
+}
+
+function removeValueGuard(inputEl: HTMLInputElement): void {
+  // Restore original property by deleting the instance override
+  delete (inputEl as unknown as Record<string, unknown>).value;
+}
+
+// Attach native listeners and value guard
+onMounted(() => {
+  const inputEl = vcInputRef.value?.inputElement;
+
+  if (!inputEl) {
+    return;
+  }
+
+  installValueGuard(inputEl);
+  inputEl.addEventListener("input", onNativeInput);
+  inputEl.addEventListener("keydown", onNativeKeydown);
+  inputEl.addEventListener("blur", onNativeBlur);
+});
+
+onBeforeUnmount(() => {
+  const inputEl = vcInputRef.value?.inputElement;
+
+  if (!inputEl) {
+    return;
+  }
+
+  removeValueGuard(inputEl);
+  inputEl.removeEventListener("input", onNativeInput);
+  inputEl.removeEventListener("keydown", onNativeKeydown);
+  inputEl.removeEventListener("blur", onNativeBlur);
+});
+
+// --- Deprecated props warnings ---
 
 if (import.meta.env.DEV) {
   const vnodeProps = getCurrentInstance()?.vnode.props ?? {};
@@ -109,7 +295,10 @@ if (import.meta.env.DEV) {
   }
 }
 
+// --- Calendar picker ---
+
 function openCalendar(focusInput: () => void): void {
+  pickerOpen = true;
   focusInput();
   const el = document.activeElement as HTMLInputElement | null;
 
@@ -119,7 +308,7 @@ function openCalendar(focusInput: () => void): void {
 
   /**
    * Workaround for multiple date inputs in Firefox: delay ensures picker opens on first click when switching.
-   * Do not remove without testing in Firefox (especially  on MacOS).
+   * Do not remove without testing in Firefox (especially on MacOS).
    */
   setTimeout(() => {
     if (typeof el.showPicker === "function") {


### PR DESCRIPTION
## Description

## References
### Jira-link:
<!-- Put link to your task in Jira here -->
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.47.0-pr-2264-85e5-85e58ce7.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core input/value propagation and installs native listeners plus an input `value` setter override, which could affect date editing behavior across browsers and integration expectations, though scope is limited to this component and is covered by new tests.
> 
> **Overview**
> Improves `VcDateSelector`’s native date-input handling to avoid Chrome mid-edit segment resets by switching to one-way binding, guarding against focused empty `value` writes, and only committing to `v-model` on complete values (or clearing on blur).
> 
> Adds structured component events `@input`, `@change`, and `@blur` (with `eventSource` distinguishing keyboard vs picker vs blur), plus min/max validity metadata; includes new global TS event types, a Storybook `EventsDemo`, and a comprehensive Vitest suite covering event semantics and picker-source behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85e58ce7863f467b97e70a09304f226d9c1f2542. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->