### PR TITLE
fix(VCST-4987): rollback text section maxLength validation for configurable products

### DIFF
--- a/client-app/shared/catalog/composables/useConfigurableProduct.ts
+++ b/client-app/shared/catalog/composables/useConfigurableProduct.ts
@@ -215,18 +215,10 @@ function _useConfigurableProduct(configurableProductId: MaybeRef<string>) {
           : { isValid, error: t("shared.catalog.product_details.product_configuration.required_section") };
       }
       case CONFIGURABLE_SECTION_TYPES.text: {
-        if (section.isRequired && !value?.customText?.trim()) {
-          return { isValid: false, error: t("shared.catalog.product_details.product_configuration.required_section") };
-        }
-        if (section.maxLength && value?.customText && value.customText.length > section.maxLength) {
-          return {
-            isValid: false,
-            error: t("shared.catalog.product_details.product_configuration.max_length_exceeded", {
-              max: section.maxLength,
-            }),
-          };
-        }
-        return { isValid: true };
+        const isValid = !section.isRequired || !!value?.customText?.trim();
+        return isValid
+          ? { isValid }
+          : { isValid, error: t("shared.catalog.product_details.product_configuration.required_section") };
       }
       case CONFIGURABLE_SECTION_TYPES.file: {
         const isValid = !section.isRequired || !!value?.files?.length;

--- a/locales/de.json
+++ b/locales/de.json
@@ -698,7 +698,6 @@
           "changed_confirmation": "Die Produktkonfiguration wurde geändert. Möchten Sie sie speichern?",
           "check_your_configuration": "Überprüfe deine Produktkonfiguration",
           "required_section": "Abschnitt erforderlich",
-          "max_length_exceeded": "Der Text darf {max} Zeichen nicht überschreiten",
           "optional_no_selected": "Personalisieren Sie Ihre Auswahl weiter (optional)",
           "required_no_selected": "Bitte alle erforderlichen Optionen auswählen, um Ihre Auswahl abzuschließen.",
           "section-text-fieldset": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -698,7 +698,6 @@
           "changed_confirmation": "The product configuration has been changed. Do you want to save it?",
           "check_your_configuration": "Check your product configuration",
           "required_section": "Section is required",
-          "max_length_exceeded": "Text must not exceed {max} characters",
           "optional_no_selected": "Personalize your selection further (optional)",
           "required_no_selected": "Complete all required options to finalize your selection",
           "section-text-fieldset": {

--- a/locales/es.json
+++ b/locales/es.json
@@ -698,7 +698,6 @@
           "changed_confirmation": "La configuración del producto ha sido cambiada. ¿Quieres guardarla?",
           "check_your_configuration": "Verifica la configuración de tu producto",
           "required_section": "La sección es obligatoria",
-          "max_length_exceeded": "El texto no debe superar {max} caracteres",
           "optional_no_selected": "Personaliza aún más tu selección (opcional)",
           "required_no_selected": "Completa todas las opciones obligatorias para finalizar tu selección",
           "section-text-fieldset": {

--- a/locales/fi.json
+++ b/locales/fi.json
@@ -698,7 +698,6 @@
           "changed_confirmation": "Tuotteen kokoonpano on muuttunut. Haluatko tallentaa sen?",
           "check_your_configuration": "Tarkista tuotteen kokoonpano",
           "required_section": "Osio on pakollinen",
-          "max_length_exceeded": "Teksti ei voi ylittää {max} merkkiä",
           "optional_no_selected": "Mukauta valintaasi lisää (valinnainen)",
           "required_no_selected": "Täytä kaikki pakolliset vaihtoehdot viimeistelläksesi valintasi",
           "section-text-fieldset": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -698,7 +698,6 @@
           "changed_confirmation": "La configuration du produit a été modifiée. Vous souhaitez-vous enregistrer les modifications ?",
           "check_your_configuration": "Vérifiez la configuration de votre produit",
           "required_section": "La section est obligatoire",
-          "max_length_exceeded": "Le texte ne doit pas dépasser {max} caractères",
           "optional_no_selected": "Personnalisez davantage votre sélection (facultatif)",
           "required_no_selected": "Veuillez compléter toutes les options requises pour finaliser votre sélection.",
           "section-text-fieldset": {

--- a/locales/it.json
+++ b/locales/it.json
@@ -698,7 +698,6 @@
           "changed_confirmation": "La configurazione del prodotto è stata modificata. Vuoi salvarla?",
           "check_your_configuration": "Verifica la configurazione del prodotto",
           "required_section": "Sezione obbligatoria",
-          "max_length_exceeded": "Il testo non deve superare {max} caratteri",
           "optional_no_selected": "Personalizza ulteriormente la tua selezione (opzionale)",
           "required_no_selected": "Completa tutte le opzioni obbligatorie per finalizzare la selezione",
           "section-text-fieldset": {

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -698,7 +698,6 @@
           "changed_confirmation": "商品の設定が変更されました。保存しますか？",
           "check_your_configuration": "製品構成を確認してください",
           "required_section": "セクションは必須です",
-          "max_length_exceeded": "テキストは {max} 文字を超えることはできません",
           "optional_no_selected": "さらに選択をパーソナライズ（任意）",
           "required_no_selected": "すべての必須オプションを選択して、完了してください",
           "section-text-fieldset": {

--- a/locales/no.json
+++ b/locales/no.json
@@ -698,7 +698,6 @@
           "changed_confirmation": "Produktkonfigurasjonen er endret. Vil du lagre den?",
           "check_your_configuration": "Sjekk produktkonfigurasjonen",
           "required_section": "Seksjonen er obligatorisk",
-          "max_length_exceeded": "Teksten kan ikke overstige {max} tegn",
           "optional_no_selected": "Tilpass valget ditt ytterligere (valgfritt)",
           "required_no_selected": "Fyll ut alle obligatoriske alternativer for å fullføre valget ditt",
           "section-text-fieldset": {

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -698,7 +698,6 @@
           "changed_confirmation": "Konfiguracja produktu została zmieniona. Chcesz ją zapisać?",
           "check_your_configuration": "Sprawdź konfigurację produktu",
           "required_section": "Sekcja jest wymagana",
-          "max_length_exceeded": "Tekst nie może przekraczać {max} znaków",
           "optional_no_selected": "Spersonalizuj swój wybór (opcjonalne)",
           "required_no_selected": "Uzupełnij wszystkie wymagane opcje, aby sfinalizować wybór",
           "section-text-fieldset": {

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -698,7 +698,6 @@
           "changed_confirmation": "A configuração do produto foi alterada. Você quer salvar?",
           "check_your_configuration": "Verifique a configuração do produto",
           "required_section": "Secção obrigatória",
-          "max_length_exceeded": "O texto não deve exceder {max} caracteres",
           "optional_no_selected": "Personalize ainda mais a sua seleção (opcional)",
           "required_no_selected": "Complete todas as opções obrigatórias para finalizar a sua seleção",
           "section-text-fieldset": {

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -698,7 +698,6 @@
           "changed_confirmation": "Конфигурация товара была изменена. Вы хотите ее сохранить?",
           "check_your_configuration": "Проверьте конфигурацию товара",
           "required_section": "Раздел обязателен",
-          "max_length_exceeded": "Текст не должен превышать {max} символов",
           "optional_no_selected": "Персонализируйте свой выбор (необязательно)",
           "required_no_selected": "Завершите выбор, указав все необходимые параметры",
           "section-text-fieldset": {

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -698,7 +698,6 @@
           "changed_confirmation": "Produktkonfigurationen har ändrats. Vill du spara den?",
           "check_your_configuration": "Kontrollera din produktkonfiguration",
           "required_section": "Sektionen är obligatorisk",
-          "max_length_exceeded": "Texten får inte överstiga {max} tecken",
           "optional_no_selected": "Anpassa ditt val ytterligare (valfritt)",
           "required_no_selected": "Slutför alla obligatoriska alternativ för att slutföra ditt val",
           "section-text-fieldset": {

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -698,7 +698,6 @@
           "changed_confirmation": "产品配置已更改。您要保存吗？",
           "check_your_configuration": "检查您的产品配置",
           "required_section": "此部分为必填项",
-          "max_length_exceeded": "文本长度不能超过 {max} 个字符",
           "optional_no_selected": "个性化您的选择（可选）",
           "required_no_selected": "请填写所有必填选项以完成选择",
           "section-text-fieldset": {


### PR DESCRIPTION
## Description

## References
### Jira-link:
<!-- Put link to your task in Jira here -->
https://virtocommerce.atlassian.net/browse/VCST-4987
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.48.0-pr-2268-fe2b-fe2b1cc2.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes client-side max-length enforcement for configurable product text sections, which may allow longer inputs to reach downstream APIs/storage. Otherwise the change is localized to validation and i18n strings.
> 
> **Overview**
> Stops validating `CONFIGURABLE_SECTION_TYPES.text` sections against `section.maxLength` in `useConfigurableProduct.validateValue`, leaving only the required/non-empty check.
> 
> Removes the now-unused `product_configuration.max_length_exceeded` i18n string from all locale JSON files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe2b1cc2335de0db3264c3df01b8b82164482f97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->