### PR TITLE
VCST-4958: Use refactored autotests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,6 @@ on:
 
 jobs:
   release:
-    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.12
+    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.30
     secrets:
       envPAT: ${{ secrets.REPO_TOKEN }}

--- a/.github/workflows/theme-ci.yml
+++ b/.github/workflows/theme-ci.yml
@@ -249,61 +249,28 @@ jobs:
           Add-Content -Path $env:GITHUB_OUTPUT -Value "branchName=$branchName"
   auto-tests:
     needs: ci
-    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@VCST-4958
+    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.30
     with:
       installModules: 'false'
       installCustomModule: 'false'
-      vctestingRepoBranch: 'test-VCST-4958' #'dev'
+      vctestingRepoBranch: 'dev'
       frontendZipUrl: '${{ needs.ci.outputs.artifactUrl }}'
       customPackagesJsonUrl: 'https://github.com/${{ github.repository }}/raw/${{ needs.ci.outputs.branchName }}/backend-packages.json'
       testSuites: 'graphql,e2e'
     secrets:
       envPAT: ${{ secrets.REPO_TOKEN }}
-      testSecretEnvFile: ${{ secrets.VC_TESTING_MODULE_ENV_FILE_NEW }} #${{ secrets.VC_TESTING_MODULE_ENV_FILE }}
+      testSecretEnvFile: ${{ secrets.VC_TESTING_MODULE_ENV_FILE }}
       sendgridApiKey: ${{ secrets.SENDGRID_APIKEY_4E2E_AUTOTESTS }}
-  # ui-e2e-auto-tests:
-  #   needs: 'ci'
-  #   if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
-  #       (github.event_name == 'workflow_dispatch') || (github.base_ref == 'dev') && (github.event_name == 'pull_request') }}
-  #   uses: VirtoCommerce/.github/.github/workflows/e2e-autotests.yml@v3.800.29
-  #   with:
-  #     installModules: 'false'
-  #     installCustomModule: 'false'
-  #     runTests: 'true'
-  #     vctestingRepoBranch: 'dev'
-  #     frontendZipUrl: '${{ needs.ci.outputs.artifactUrl }}'
-  #     customPackagesJsonUrl: 'https://github.com/${{ github.repository }}/raw/${{ needs.ci.outputs.branchName }}/backend-packages.json'
-  #   secrets:
-  #     envPAT: ${{ secrets.REPO_TOKEN }}
-  #     testSecretEnvFile: ${{ secrets.VC_TESTING_MODULE_ENV_FILE }}
-  #     sendgridApiKey: ${{ secrets.SENDGRID_APIKEY_4E2E_AUTOTESTS }}
-
-  # ui-auto-tests:
-  #   needs: 'ci'
-  #   if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
-  #     (github.base_ref == 'dev') && (github.event_name == 'pull_request') || 
-  #     (github.event_name == 'workflow_dispatch') }}
-  #   uses: VirtoCommerce/.github/.github/workflows/ui-autotests.yml@v3.800.29
-  #   with:
-  #     installModules: 'true'
-  #     installCustomModule: 'false'
-  #     platformDockerTag: 'linux-latest'
-  #     frontendZipUrl: '${{ needs.ci.outputs.artifactUrl }}'
-  #     vctestingRepoBranch: 'dev'
-  #   secrets:
-  #     envPAT: ${{ secrets.REPO_TOKEN }}
-  #     testSecretEnvFile: ${{ secrets.VC_TESTING_MODULE_ENV_FILE }}
-  #     sendgridApiKey: ${{ secrets.SENDGRID_APIKEY_4E2E_AUTOTESTS }}
-
-  # deploy-cloud:
-  #   if: ${{ github.ref == 'refs/heads/dev' || github.event_name == 'pull_request'}}
-  #   needs: ci
-  #   uses: ./.github/workflows/deploy-cloud.yml
-  #   with:
-  #     cmPath: 'theme/artifact.json'
-  #     artifactKey: 'URL'
-  #     artifactUrl: ${{ needs.ci.outputs.artifactUrl }}
-  #     environmentId: ${{ ((github.event_name == 'pull_request' && github.base_ref == 'dev') || github.ref == 'refs/heads/master') && 'qa' || 'dev' }}
-  #     jiraKeys: ${{ needs.ci.outputs.jira-keys }}
-  #     forceCommit: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev' }}
-  #   secrets: inherit
+  
+  deploy-cloud:
+    if: ${{ github.ref == 'refs/heads/dev' || github.event_name == 'pull_request'}}
+    needs: ci
+    uses: ./.github/workflows/deploy-cloud.yml
+    with:
+      cmPath: 'theme/artifact.json'
+      artifactKey: 'URL'
+      artifactUrl: ${{ needs.ci.outputs.artifactUrl }}
+      environmentId: ${{ ((github.event_name == 'pull_request' && github.base_ref == 'dev') || github.ref == 'refs/heads/master') && 'qa' || 'dev' }}
+      jiraKeys: ${{ needs.ci.outputs.jira-keys }}
+      forceCommit: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev' }}
+    secrets: inherit

--- a/.github/workflows/theme-ci.yml
+++ b/.github/workflows/theme-ci.yml
@@ -253,7 +253,7 @@ jobs:
     with:
       installModules: 'false'
       installCustomModule: 'false'
-      vctestingRepoBranch: 'VCST-4958' #'dev'
+      vctestingRepoBranch: 'test-VCST-4958' #'dev'
       frontendZipUrl: '${{ needs.ci.outputs.artifactUrl }}'
       customPackagesJsonUrl: 'https://github.com/${{ github.repository }}/raw/${{ needs.ci.outputs.branchName }}/backend-packages.json'
       testSuites: 'graphql,e2e'

--- a/.github/workflows/theme-ci.yml
+++ b/.github/workflows/theme-ci.yml
@@ -247,50 +247,63 @@ jobs:
             $branchName = $env:REF_NAME
           }
           Add-Content -Path $env:GITHUB_OUTPUT -Value "branchName=$branchName"
-
-  ui-e2e-auto-tests:
-    needs: 'ci'
-    if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
-        (github.event_name == 'workflow_dispatch') || (github.base_ref == 'dev') && (github.event_name == 'pull_request') }}
-    uses: VirtoCommerce/.github/.github/workflows/e2e-autotests.yml@v3.800.29
+  auto-tests:
+    needs: ci
+    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@VCST-4958
     with:
       installModules: 'false'
       installCustomModule: 'false'
-      runTests: 'true'
-      vctestingRepoBranch: 'dev'
+      vctestingRepoBranch: 'VCST-4958' #'dev'
       frontendZipUrl: '${{ needs.ci.outputs.artifactUrl }}'
       customPackagesJsonUrl: 'https://github.com/${{ github.repository }}/raw/${{ needs.ci.outputs.branchName }}/backend-packages.json'
+      testSuites: 'graphql,e2e'
     secrets:
       envPAT: ${{ secrets.REPO_TOKEN }}
-      testSecretEnvFile: ${{ secrets.VC_TESTING_MODULE_ENV_FILE }}
+      testSecretEnvFile: ${{ secrets.VC_TESTING_MODULE_ENV_FILE_NEW }} #${{ secrets.VC_TESTING_MODULE_ENV_FILE }}
       sendgridApiKey: ${{ secrets.SENDGRID_APIKEY_4E2E_AUTOTESTS }}
+  # ui-e2e-auto-tests:
+  #   needs: 'ci'
+  #   if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
+  #       (github.event_name == 'workflow_dispatch') || (github.base_ref == 'dev') && (github.event_name == 'pull_request') }}
+  #   uses: VirtoCommerce/.github/.github/workflows/e2e-autotests.yml@v3.800.29
+  #   with:
+  #     installModules: 'false'
+  #     installCustomModule: 'false'
+  #     runTests: 'true'
+  #     vctestingRepoBranch: 'dev'
+  #     frontendZipUrl: '${{ needs.ci.outputs.artifactUrl }}'
+  #     customPackagesJsonUrl: 'https://github.com/${{ github.repository }}/raw/${{ needs.ci.outputs.branchName }}/backend-packages.json'
+  #   secrets:
+  #     envPAT: ${{ secrets.REPO_TOKEN }}
+  #     testSecretEnvFile: ${{ secrets.VC_TESTING_MODULE_ENV_FILE }}
+  #     sendgridApiKey: ${{ secrets.SENDGRID_APIKEY_4E2E_AUTOTESTS }}
 
-  ui-auto-tests:
-    needs: 'ci'
-    if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
-      (github.base_ref == 'dev') && (github.event_name == 'pull_request') || 
-      (github.event_name == 'workflow_dispatch') }}
-    uses: VirtoCommerce/.github/.github/workflows/ui-autotests.yml@v3.800.29
-    with:
-      installModules: 'true'
-      installCustomModule: 'false'
-      platformDockerTag: 'linux-latest'
-      frontendZipUrl: '${{ needs.ci.outputs.artifactUrl }}'
-      vctestingRepoBranch: 'dev'
-    secrets:
-      envPAT: ${{ secrets.REPO_TOKEN }}
-      testSecretEnvFile: ${{ secrets.VC_TESTING_MODULE_ENV_FILE }}
-      sendgridApiKey: ${{ secrets.SENDGRID_APIKEY_4E2E_AUTOTESTS }}
+  # ui-auto-tests:
+  #   needs: 'ci'
+  #   if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
+  #     (github.base_ref == 'dev') && (github.event_name == 'pull_request') || 
+  #     (github.event_name == 'workflow_dispatch') }}
+  #   uses: VirtoCommerce/.github/.github/workflows/ui-autotests.yml@v3.800.29
+  #   with:
+  #     installModules: 'true'
+  #     installCustomModule: 'false'
+  #     platformDockerTag: 'linux-latest'
+  #     frontendZipUrl: '${{ needs.ci.outputs.artifactUrl }}'
+  #     vctestingRepoBranch: 'dev'
+  #   secrets:
+  #     envPAT: ${{ secrets.REPO_TOKEN }}
+  #     testSecretEnvFile: ${{ secrets.VC_TESTING_MODULE_ENV_FILE }}
+  #     sendgridApiKey: ${{ secrets.SENDGRID_APIKEY_4E2E_AUTOTESTS }}
 
-  deploy-cloud:
-    if: ${{ github.ref == 'refs/heads/dev' || github.event_name == 'pull_request'}}
-    needs: ci
-    uses: ./.github/workflows/deploy-cloud.yml
-    with:
-      cmPath: 'theme/artifact.json'
-      artifactKey: 'URL'
-      artifactUrl: ${{ needs.ci.outputs.artifactUrl }}
-      environmentId: ${{ ((github.event_name == 'pull_request' && github.base_ref == 'dev') || github.ref == 'refs/heads/master') && 'qa' || 'dev' }}
-      jiraKeys: ${{ needs.ci.outputs.jira-keys }}
-      forceCommit: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev' }}
-    secrets: inherit
+  # deploy-cloud:
+  #   if: ${{ github.ref == 'refs/heads/dev' || github.event_name == 'pull_request'}}
+  #   needs: ci
+  #   uses: ./.github/workflows/deploy-cloud.yml
+  #   with:
+  #     cmPath: 'theme/artifact.json'
+  #     artifactKey: 'URL'
+  #     artifactUrl: ${{ needs.ci.outputs.artifactUrl }}
+  #     environmentId: ${{ ((github.event_name == 'pull_request' && github.base_ref == 'dev') || github.ref == 'refs/heads/master') && 'qa' || 'dev' }}
+  #     jiraKeys: ${{ needs.ci.outputs.jira-keys }}
+  #     forceCommit: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev' }}
+  #   secrets: inherit

--- a/.github/workflows/theme-ci.yml
+++ b/.github/workflows/theme-ci.yml
@@ -258,7 +258,7 @@ jobs:
       vctestingRepoBranch: 'dev'
       frontendZipUrl: '${{ needs.ci.outputs.artifactUrl }}'
       customPackagesJsonUrl: 'https://github.com/${{ github.repository }}/raw/${{ needs.ci.outputs.branchName }}/backend-packages.json'
-      testSuites: 'graphql,e2e'
+      testSuites: 'graphql,e2e,restapi'
     secrets:
       envPAT: ${{ secrets.REPO_TOKEN }}
       testSecretEnvFile: ${{ secrets.VC_TESTING_MODULE_ENV_FILE }}

--- a/.github/workflows/theme-ci.yml
+++ b/.github/workflows/theme-ci.yml
@@ -249,6 +249,8 @@ jobs:
           Add-Content -Path $env:GITHUB_OUTPUT -Value "branchName=$branchName"
   auto-tests:
     needs: ci
+    if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
+        (github.event_name == 'workflow_dispatch') || (github.base_ref == 'dev') && (github.event_name == 'pull_request') }}
     uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.30
     with:
       installModules: 'false'


### PR DESCRIPTION
## Description
Use new workflow running graphql and e2e autotests. 
## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4958
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.48.0-pr-2270-617a-617a2d29.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI-only changes, but they alter which automated test workflows run and how they are invoked, which could cause missed coverage or failing pipelines if misconfigured.
> 
> **Overview**
> Updates the `Release` workflow to use VirtoCommerce reusable workflows `v3.800.30`.
> 
> Refactors `theme-ci.yml` autotesting by replacing the previous UI/e2e autotest jobs with a single `auto-tests` job that calls `pytest-tests.yml@v3.800.30` and runs `graphql,e2e,restapi` suites against the built frontend artifact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 617a2d294b7ef31d37432edfe188c05dfcfc87c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->