### PR TITLE
fix(VCST-5029): add data-address-id to pickup list item for auto-scroll

### DIFF
--- a/client-app/shared/checkout/components/select-address-map/select-address-map-list.vue
+++ b/client-app/shared/checkout/components/select-address-map/select-address-map-list.vue
@@ -10,6 +10,7 @@
       <div
         v-for="address in addresses"
         :key="address.id"
+        :data-address-id="address.id"
         :data-country="address.address?.countryName"
         :data-region="address.address?.regionId"
         :data-city="address.address?.city"


### PR DESCRIPTION
## Description

## References
### Jira-link:
<!-- Put link to your task in Jira here -->
https://virtocommerce.atlassian.net/browse/VCST-5029
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.49.0-pr-2283-6f59-6f593a46.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small template-only change that adds a DOM `data-*` attribute used for scrolling/focus, with no business logic or data flow changes.
> 
> **Overview**
> Fixes pickup-point auto-scroll/focus by adding a `data-address-id` attribute to each pickup location list item in `select-address-map-list.vue`, aligning the rendered DOM with selectors used by the map/list scrolling logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f593a46b5edb246efa2cf41f3c9d2b558e11578. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->