### PR TITLE
fix(VCST-4993): change area label for select address modal

### DIFF
--- a/client-app/shared/checkout/components/select-address-filter.vue
+++ b/client-app/shared/checkout/components/select-address-filter.vue
@@ -54,7 +54,7 @@
       <VcInput
         v-model="filterKeyword"
         :placeholder="$t('common.labels.search')"
-        :aria-label="$t('pages.account.order_details.bopis.search_pickup_locations')"
+        :aria-label="$t(searchAriaLabelKey)"
         size="sm"
         class="select-address-filter__keyword"
         test-id-input="search-keyword-input"
@@ -143,6 +143,7 @@ const {
   filterSelectsAreEmpty,
   clearFilter,
   pickupLocationsLoading,
+  searchAriaLabelKey,
 } = usePickupFilterContext();
 
 const hasFacetFilters = computed(

--- a/client-app/shared/checkout/composables/usePickupFilterContext.ts
+++ b/client-app/shared/checkout/composables/usePickupFilterContext.ts
@@ -17,6 +17,7 @@ export interface IPickupFilterContext {
   filterSelectsAreEmpty: ComputedRef<boolean>;
   filterIsApplied: Ref<boolean>;
   pickupLocationsLoading: Ref<boolean>;
+  searchAriaLabelKey: string;
   clearFilter: () => void;
   buildFilter: () => string | undefined;
 }
@@ -64,6 +65,7 @@ export function createCartFilterContext(): IPickupFilterContext {
     filterSelectsAreEmpty,
     filterIsApplied,
     pickupLocationsLoading,
+    searchAriaLabelKey: "pages.account.order_details.bopis.search_pickup_locations",
     clearFilter,
     buildFilter,
   });
@@ -149,6 +151,7 @@ export function createAddressFilterContext(options: {
     filterSelectsAreEmpty,
     filterIsApplied,
     pickupLocationsLoading: options.loading,
+    searchAriaLabelKey: "shared.checkout.select_address_modal.search_addresses_aria_label",
     clearFilter,
     buildFilter,
   });
@@ -188,6 +191,7 @@ export function createProductFilterContext(options: { loading: Ref<boolean> }): 
     filterSelectsAreEmpty,
     filterIsApplied,
     pickupLocationsLoading: options.loading,
+    searchAriaLabelKey: "pages.account.order_details.bopis.search_pickup_locations",
     clearFilter,
     buildFilter,
   });

--- a/locales/de.json
+++ b/locales/de.json
@@ -805,6 +805,7 @@
         "phone_label": "@:common.labels.phone{':' }",
         "email_label": "@:common.labels.email{':' }",
         "no_addresses_message": "Sie haben noch keine Adressen",
+        "search_addresses_aria_label": "Adressen suchen",
         "title": "Adresse auswählen"
       },
       "shipping_method_modal": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -805,6 +805,7 @@
         "phone_label": "@:common.labels.phone{':'}",
         "email_label": "@:common.labels.email{':'}",
         "no_addresses_message": "You do not have any addresses yet",
+        "search_addresses_aria_label": "Search addresses",
         "title": "Select address"
       },
       "shipping_method_modal": {

--- a/locales/es.json
+++ b/locales/es.json
@@ -805,6 +805,7 @@
         "phone_label": "@:common.labels.phone{':'}",
         "email_label": "@:common.labels.email{':'}",
         "no_addresses_message": "Aún no tienes ninguna dirección",
+        "search_addresses_aria_label": "Buscar direcciones",
         "title": "Seleccionar dirección"
       },
       "shipping_method_modal": {

--- a/locales/fi.json
+++ b/locales/fi.json
@@ -805,6 +805,7 @@
         "phone_label": "@:common.labels.phone{':'}",
         "email_label": "@:common.labels.email{':'}",
         "no_addresses_message": "Sinulla ei ole vielä osoitteita",
+        "search_addresses_aria_label": "Hae osoitteita",
         "title": "Valitse osoite"
       },
       "shipping_method_modal": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -805,6 +805,7 @@
         "phone_label": "@:common.labels.phone{':' }",
         "email_label": "@:common.labels.email{':' }",
         "no_addresses_message": "Vous n'avez pas encore d'adresses",
+        "search_addresses_aria_label": "Rechercher des adresses",
         "title": "Sélectionner une adresse"
       },
       "shipping_method_modal": {

--- a/locales/it.json
+++ b/locales/it.json
@@ -805,6 +805,7 @@
         "phone_label": "@:common.labels.phone{':'}",
         "email_label": "@:common.labels.email{':'}",
         "no_addresses_message": "Non hai ancora nessun indirizzo",
+        "search_addresses_aria_label": "Cerca indirizzi",
         "title": "Seleziona indirizzo"
       },
       "shipping_method_modal": {

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -805,6 +805,7 @@
         "phone_label": "@:common.labels.phone{':'}",
         "email_label": "@:common.labels.email{':'}",
         "no_addresses_message": "住所が登録されていません",
+        "search_addresses_aria_label": "住所を検索",
         "title": "住所を選択"
       },
       "shipping_method_modal": {

--- a/locales/no.json
+++ b/locales/no.json
@@ -805,6 +805,7 @@
         "phone_label": "@:common.labels.phone{':'}",
         "email_label": "@:common.labels.email{':'}",
         "no_addresses_message": "Du har ingen adresser ennå",
+        "search_addresses_aria_label": "Søk etter adresser",
         "title": "Velg adresse"
       },
       "shipping_method_modal": {

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -805,6 +805,7 @@
         "phone_label": "@:common.labels.phone{':'}",
         "email_label": "@:common.labels.email{':'}",
         "no_addresses_message": "Nie masz jeszcze żadnych adresów",
+        "search_addresses_aria_label": "Szukaj adresów",
         "title": "Wybierz adres"
       },
       "shipping_method_modal": {

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -805,6 +805,7 @@
         "phone_label": "@:common.labels.phone{':'}",
         "email_label": "@:common.labels.email{':'}",
         "no_addresses_message": "Você ainda não tem nenhum endereço",
+        "search_addresses_aria_label": "Pesquisar endereços",
         "title": "Selecionar endereço"
       },
       "shipping_method_modal": {

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -805,6 +805,7 @@
         "phone_label": "@:common.labels.phone{':'}",
         "email_label": "@:common.labels.email{':'}",
         "no_addresses_message": "У вас пока нет адресов",
+        "search_addresses_aria_label": "Поиск адресов",
         "title": "Выбрать адрес"
       },
       "shipping_method_modal": {

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -805,6 +805,7 @@
         "phone_label": "@:common.labels.phone{':'}",
         "email_label": "@:common.labels.email{':'}",
         "no_addresses_message": "Du har inga adresser ännu",
+        "search_addresses_aria_label": "Sök adresser",
         "title": "Välj adress"
       },
       "shipping_method_modal": {

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -805,6 +805,7 @@
         "phone_label": "@:common.labels.phone{':'}",
         "email_label": "@:common.labels.email{':'}",
         "no_addresses_message": "您尚未有任何地址",
+        "search_addresses_aria_label": "搜索地址",
         "title": "选择地址"
       },
       "shipping_method_modal": {


### PR DESCRIPTION
## Description

## References
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4993
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.49.0-pr-2287-367d-367d16a1.zip