### PR TITLE
chore(VCST-5041): update workflow versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,6 @@ on:
 
 jobs:
   release:
-    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.30
+    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.31
     secrets:
       envPAT: ${{ secrets.REPO_TOKEN }}

--- a/.github/workflows/theme-ci.yml
+++ b/.github/workflows/theme-ci.yml
@@ -251,7 +251,7 @@ jobs:
     needs: ci
     if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
         (github.event_name == 'workflow_dispatch') || (github.base_ref == 'dev') && (github.event_name == 'pull_request') }}
-    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.30
+    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.31
     with:
       installModules: 'false'
       installCustomModule: 'false'


### PR DESCRIPTION
## Description

## References
### Jira-link:
[<!-- Put link to your task in Jira here -->](https://virtocommerce.atlassian.net/browse/VCST-5041)
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.49.0-pr-2288-80e8-80e8a59a.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk version-bump of referenced reusable GitHub workflows; behavior changes (if any) are confined to CI/release pipelines.
> 
> **Overview**
> Updates CI to use the newer VirtoCommerce reusable workflows `@v3.800.31` for both the `Release` workflow and the `auto-tests` job in `theme-ci.yml` (previously `@v3.800.30`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80e8a59a68e99c21cbe66277ce1c64e9b73e0c78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->