### PR TITLE
chore(VCST-4843): pin third-party actions to SHAs and automate updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,31 @@
+# Workflows
+
+GitHub Actions workflows for this repo. This document covers the supply-chain security setup; for what each workflow does, see the individual files.
+
+## Supply-chain security: pinned third-party actions
+
+Every third-party `uses:` reference in this repo (anything not under `VirtoCommerce/*`) is pinned to a full 40-character commit SHA with a trailing `# tag` comment, per the [GitHub Actions hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions). Tags are mutable; SHAs are not.
+
+```yaml
+# Correct
+uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+# Rejected by CI
+uses: actions/checkout@v6
+```
+
+### How updates happen
+
+- **Dependabot** ([`.github/dependabot.yml`](../dependabot.yml)) scans `.github/workflows/` weekly. When upstream cuts a new tag, it opens a grouped PR bumping the SHA + trailing comment.
+- **Pin-check CI** ([`pin-check.yml`](pin-check.yml)) runs `pinact run -check` on every PR that touches workflows. PRs with unpinned third-party `uses:` lines fail.
+- **Scope** is configured in [`.pinact.yaml`](../../.pinact.yaml) at the repo root — `VirtoCommerce/*` is intentionally ignored (internal, not third-party).
+
+### For contributors
+
+- When adding a new third-party action, write the SHA, not the tag. Quick lookup:
+
+  ```sh
+  gh api repos/OWNER/REPO/commits/TAG --jq '.sha'
+  ```
+
+- `VirtoCommerce/vc-github-actions/<dir>@master` and other `VirtoCommerce/*` refs remain version-/branch-pinned as before — only non-VirtoCommerce owners require SHA pinning.

--- a/.github/workflows/pin-check.yml
+++ b/.github/workflows/pin-check.yml
@@ -1,0 +1,34 @@
+name: Verify action pinning
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '**/action.yml'
+      - '**/action.yaml'
+      - '.pinact.yaml'
+
+permissions:
+  contents: read
+
+jobs:
+  pinact:
+    runs-on: ubuntu-latest
+    env:
+      PINACT_VERSION: v3.10.1
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install pinact
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          cd "$RUNNER_TEMP"
+          gh release download "$PINACT_VERSION" \
+            --repo suzuki-shunsuke/pinact \
+            --pattern 'pinact_linux_amd64.tar.gz'
+          tar -xzf pinact_linux_amd64.tar.gz
+          sudo install pinact /usr/local/bin/
+
+      - name: Verify all third-party actions are pinned to SHAs
+        run: pinact run -check

--- a/.github/workflows/storybook-ci.yml
+++ b/.github/workflows/storybook-ci.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
 
       - name: Set up Node 22
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '22'
 
@@ -54,7 +54,7 @@ jobs:
         run: |
           echo "RELEASE_STATUS=true" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
@@ -127,17 +127,17 @@ jobs:
           echo "BLOB_URL=${{ steps.blobRelease.outputs.packageUrl }}" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: ${{ env.DOCKER_REPOSITORY }}
           username: $GITHUB_ACTOR
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
         with:
           push: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/master')}}
           context: .

--- a/.github/workflows/theme-ci.yml
+++ b/.github/workflows/theme-ci.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
 
       - name: Set up Node 22
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '22'
 
@@ -56,7 +56,7 @@ jobs:
         run: |
           echo "RELEASE_STATUS=true" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
@@ -97,7 +97,7 @@ jobs:
           yarn install
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@v7.1.0
+        uses: SonarSource/sonarqube-scan-action@299e4b793aaa83bf2aba7c9c14bedbb485688ec4 # v7.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -120,7 +120,7 @@ jobs:
           yarn test:coverage
 
       - name: Upload Coverage Report
-        uses:  actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-report
           path: coverage
@@ -158,7 +158,7 @@ jobs:
           downloadComment: 'Artifact URL:'
 
       - name: Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         id: create_release
         if: ${{ github.ref == 'refs/heads/master' }}
         with:

--- a/.github/workflows/theme-release-hotfix.yml
+++ b/.github/workflows/theme-release-hotfix.yml
@@ -12,12 +12,12 @@ jobs:
       VERSION_SUFFIX: ""
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Set up Node 22
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '22'
 
@@ -26,7 +26,7 @@ jobs:
           corepack enable
 
       - name: Setup sonarqube
-        uses: warchant/setup-sonar-scanner@v8
+        uses: warchant/setup-sonar-scanner@7559f7221c1f8637fc6be7287945e2c5b3f6dea9 # v8
 
       - name: Install VirtoCommerce.GlobalTool
         uses: VirtoCommerce/vc-github-actions/setup-vcbuild@master
@@ -59,7 +59,7 @@ jobs:
           yarn install
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
+        uses: SonarSource/sonarcloud-github-action@ba3875ecf642b2129de2b589510c81a8b53dbf4e # master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/refs/heads/main/json-schema/pinact.json
+version: 3
+
+files:
+  - pattern: ^\.github/workflows/.*\.ya?ml$
+  - pattern: ^(.*/)?action\.ya?ml$
+
+ignore_actions:
+  - name: VirtoCommerce/.*
+    ref: .*


### PR DESCRIPTION
## Description

## References
### Jira-link:
<!-- Put link to your task in Jira here -->https://virtocommerce.atlassian.net/browse/VCST-4843
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.49.0-pr-2297-c7e2-c7e231aa.zip

New pinact.yaml declaring scan paths and VirtoCommerce/* ignore.
New .github/workflows/pin-check.yml — runs pinact run -check on every PR that touches workflows or templates; fails on unpinned uses: lines.
Internal VirtoCommerce/* refs (vc-github-actions, jira-upload-*, reusable workflows) are intentionally left as version-/branch-pinned — they're not third-party.

Layers automated maintenance onto the SHA pinning from #.

.github/dependabot.yml — weekly grouped github-actions updates. Dependabot reads the # tag comment, bumps SHA + comment together when upstream cuts new tags.

README file added under .github/workflows/.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to GitHub Actions configuration/documentation and should not affect application runtime, but they can fail CI if action pins/config are incorrect.
> 
> **Overview**
> Adds **supply-chain hardening for GitHub Actions** by requiring third-party `uses:` references to be pinned to full commit SHAs (with tag comments) and documenting the policy in `.github/workflows/README.md`.
> 
> Introduces `pinact` enforcement via a new `pin-check.yml` workflow (runs on PRs that touch workflows/action manifests) plus a repo-wide `.pinact.yaml` configuration that ignores `VirtoCommerce/*`. Adds weekly grouped `github-actions` Dependabot updates to keep pinned SHAs current, and updates existing workflows to replace tag-based action refs (e.g., `actions/*`, `docker/*`, `SonarSource/*`, `softprops/*`, `warchant/*`) with SHA pins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7e231aa00197f933a7c83b93881d801eed4d3bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->