### PR TITLE
feat(VCST-5063): add param for tests, update workflows version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,6 @@ on:
 
 jobs:
   release:
-    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.31
+    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.35
     secrets:
       envPAT: ${{ secrets.REPO_TOKEN }}

--- a/.github/workflows/theme-ci.yml
+++ b/.github/workflows/theme-ci.yml
@@ -251,7 +251,7 @@ jobs:
     needs: ci
     if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
         (github.event_name == 'workflow_dispatch') || (github.base_ref == 'dev') && (github.event_name == 'pull_request') }}
-    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.31
+    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.35
     with:
       installModules: 'false'
       installCustomModule: 'false'
@@ -260,6 +260,7 @@ jobs:
       customPackagesJsonUrl: 'https://github.com/${{ github.repository }}/raw/${{ needs.ci.outputs.branchName }}/backend-packages.json'
       testSuites: 'graphql,e2e,restapi'
     secrets:
+      appInsightsInstrumentationKey: ${{ secrets.E2E_APPINSIGHTSINSTRUMENTATIONKEY }}
       envPAT: ${{ secrets.REPO_TOKEN }}
       testSecretEnvFile: ${{ secrets.VC_TESTING_MODULE_ENV_FILE }}
       sendgridApiKey: ${{ secrets.SENDGRID_APIKEY_4E2E_AUTOTESTS }}


### PR DESCRIPTION
## Description

## References
### Jira-link:
<!-- Put link to your task in Jira here -->https://virtocommerce.atlassian.net/browse/VCST-5063
### Artifact URL:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes reusable GitHub Actions workflow versions and adds a new secret input to the test workflow, which could impact CI/release execution if the upstream workflow interface or secrets are misconfigured.
> 
> **Overview**
> Updates the `Release` and `Theme CI` GitHub Actions to use the shared VirtoCommerce reusable workflows `v3.800.35` (from `v3.800.31`).
> 
> In `theme-ci.yml`, the `auto-tests` job now passes an additional secret (`appInsightsInstrumentationKey`) into the reusable `pytest-tests` workflow to enable telemetry/configuration during E2E runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52b02f1fa69777e766f6cc4464dc1ee5b5c497a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->