### PR TITLE
fix(VCST-5017): coupon-card a11y

### DIFF
--- a/client-app/shared/cart/components/coupon-card.vue
+++ b/client-app/shared/cart/components/coupon-card.vue
@@ -33,6 +33,7 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
+import { useI18n } from "vue-i18n";
 import type { GetPromotionCouponsQuery } from "@/core/api/graphql/types";
 
 type ViewType = "default" | "applied" | "error";
@@ -59,11 +60,14 @@ interface IViewConfig {
     variant: VcButtonVariantType;
     color: VcButtonColorType;
     disabled: boolean;
+    ariaLabel: string;
   };
 }
 
 const emit = defineEmits<IEmits>();
 const props = withDefaults(defineProps<IProps>(), { custom: false, modelValue: "", loading: false });
+
+const { t } = useI18n();
 
 const code = computed({
   get: () => (props.custom ? props.modelValue : (props.coupon?.couponCode ?? "")),
@@ -87,22 +91,40 @@ function handleClick() {
   }
 }
 
-const viewConfigs: Record<ViewType, IViewConfig> = {
-  default: {
-    iconName: "receipt-tax",
-    button: { icon: "arrow-right", variant: "solid", color: "primary", disabled: false },
-  },
-  applied: {
-    iconName: "round-check",
-    button: { icon: "outline-trash", variant: "no-background", color: "neutral", disabled: false },
-  },
-  error: {
-    iconName: "receipt-tax",
-    button: { icon: "arrow-right", variant: "solid", color: "primary", disabled: true },
-  },
-};
+const viewConfig = computed<IViewConfig>(() => {
+  const applyAriaLabel = t("shared.cart.coupons_section.apply_aria", { code: code.value });
+  const removeAriaLabel = t("shared.cart.coupons_section.remove_aria");
 
-const viewConfig = computed(() => viewConfigs[props.view]);
+  const applyButtonBase = {
+    icon: "arrow-right",
+    variant: "solid",
+    color: "primary",
+    ariaLabel: applyAriaLabel,
+  } as const;
+
+  const viewConfigs: Record<ViewType, IViewConfig> = {
+    default: {
+      iconName: "receipt-tax",
+      button: { ...applyButtonBase, disabled: false },
+    },
+    applied: {
+      iconName: "round-check",
+      button: {
+        icon: "outline-trash",
+        variant: "no-background",
+        color: "neutral",
+        disabled: false,
+        ariaLabel: removeAriaLabel,
+      },
+    },
+    error: {
+      iconName: "receipt-tax",
+      button: { ...applyButtonBase, disabled: true },
+    },
+  };
+
+  return viewConfigs[props.view];
+});
 </script>
 
 <style lang="scss">

--- a/client-app/shared/cart/components/coupon-card.vue
+++ b/client-app/shared/cart/components/coupon-card.vue
@@ -26,7 +26,7 @@
         {{ $t("shared.cart.coupons_section.expires") }} {{ $d(coupon.endDate, "short") }}
       </p>
 
-      <p v-if="view === 'error' && !!error" class="coupon-card__error">{{ error }}</p>
+      <p v-if="view === 'error' && !!error" role="alert" class="coupon-card__error">{{ error }}</p>
     </div>
   </div>
 </template>

--- a/locales/de.json
+++ b/locales/de.json
@@ -681,7 +681,9 @@
         "expires": "@:shared.account.promotion_coupons.expires",
         "custom_code": "Benutzerdefinierter Code",
         "enter_custom_code": "Benutzerdefinierten Code eingeben",
-        "all_coupons": "Alle Gutscheine & Aktionen anzeigen"
+        "all_coupons": "Alle Gutscheine & Aktionen anzeigen",
+        "apply_aria": "Apply coupon {code}",
+        "remove_aria": "Remove coupon"
       }
     },
     "catalog": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -681,7 +681,9 @@
         "expires": "@:shared.account.promotion_coupons.expires",
         "custom_code": "Custom code",
         "enter_custom_code": "Enter custom code",
-        "all_coupons": "View all coupons & promotions"
+        "all_coupons": "View all coupons & promotions",
+        "apply_aria": "Apply coupon {code}",
+        "remove_aria": "Remove coupon"
       }
     },
     "catalog": {

--- a/locales/es.json
+++ b/locales/es.json
@@ -681,7 +681,9 @@
         "expires": "@:shared.account.promotion_coupons.expires",
         "custom_code": "Código personalizado",
         "enter_custom_code": "Ingresar código personalizado",
-        "all_coupons": "Ver todos los cupones y promociones"
+        "all_coupons": "Ver todos los cupones y promociones",
+        "apply_aria": "Apply coupon {code}",
+        "remove_aria": "Remove coupon"
       }
     },
     "catalog": {

--- a/locales/fi.json
+++ b/locales/fi.json
@@ -681,7 +681,9 @@
         "expires": "@:shared.account.promotion_coupons.expires",
         "custom_code": "Mukautettu koodi",
         "enter_custom_code": "Syötä mukautettu koodi",
-        "all_coupons": "Näytä kaikki kupongit & tarjoukset"
+        "all_coupons": "Näytä kaikki kupongit & tarjoukset",
+        "apply_aria": "Apply coupon {code}",
+        "remove_aria": "Remove coupon"
       }
     },
     "catalog": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -681,7 +681,9 @@
         "expires": "@:shared.account.promotion_coupons.expires",
         "custom_code": "Code personnalisé",
         "enter_custom_code": "Entrez un code personnalisé",
-        "all_coupons": "Voir tous les coupons et promotions"
+        "all_coupons": "Voir tous les coupons et promotions",
+        "apply_aria": "Apply coupon {code}",
+        "remove_aria": "Remove coupon"
       }
     },
     "catalog": {

--- a/locales/it.json
+++ b/locales/it.json
@@ -681,7 +681,9 @@
         "expires": "@:shared.account.promotion_coupons.expires",
         "custom_code": "Codice personalizzato",
         "enter_custom_code": "Inserisci codice personalizzato",
-        "all_coupons": "Visualizza tutti i coupon e le promozioni"
+        "all_coupons": "Visualizza tutti i coupon e le promozioni",
+        "apply_aria": "Apply coupon {code}",
+        "remove_aria": "Remove coupon"
       }
     },
     "catalog": {

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -681,7 +681,9 @@
         "expires": "@:shared.account.promotion_coupons.expires",
         "custom_code": "カスタムコード",
         "enter_custom_code": "カスタムコードを入力",
-        "all_coupons": "すべてのクーポンとプロモーションを表示"
+        "all_coupons": "すべてのクーポンとプロモーションを表示",
+        "apply_aria": "Apply coupon {code}",
+        "remove_aria": "Remove coupon"
       }
     },
     "catalog": {

--- a/locales/no.json
+++ b/locales/no.json
@@ -681,7 +681,9 @@
         "expires": "@:shared.account.promotion_coupons.expires",
         "custom_code": "Egendefinert kode",
         "enter_custom_code": "Skriv inn egendefinert kode",
-        "all_coupons": "Se alle kuponger og kampanjer"
+        "all_coupons": "Se alle kuponger og kampanjer",
+        "apply_aria": "Apply coupon {code}",
+        "remove_aria": "Remove coupon"
       }
     },
     "catalog": {

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -681,7 +681,9 @@
         "expires": "@:shared.account.promotion_coupons.expires",
         "custom_code": "Niestandardowy kod",
         "enter_custom_code": "Wprowadź niestandardowy kod",
-        "all_coupons": "Zobacz wszystkie kupony i promocje"
+        "all_coupons": "Zobacz wszystkie kupony i promocje",
+        "apply_aria": "Apply coupon {code}",
+        "remove_aria": "Remove coupon"
       }
     },
     "catalog": {

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -681,7 +681,9 @@
         "expires": "@:shared.account.promotion_coupons.expires",
         "custom_code": "Código personalizado",
         "enter_custom_code": "Inserir código personalizado",
-        "all_coupons": "Ver todos os cupons e promoções"
+        "all_coupons": "Ver todos os cupons e promoções",
+        "apply_aria": "Apply coupon {code}",
+        "remove_aria": "Remove coupon"
       }
     },
     "catalog": {

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -681,7 +681,9 @@
         "expires": "@:shared.account.promotion_coupons.expires",
         "custom_code": "Пользовательский код",
         "enter_custom_code": "Введите пользовательский код",
-        "all_coupons": "Посмотреть все купоны и акции"
+        "all_coupons": "Посмотреть все купоны и акции",
+        "apply_aria": "Применить купон {code}",
+        "remove_aria": "Удалить купон"
       }
     },
     "catalog": {

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -681,7 +681,9 @@
         "expires": "@:shared.account.promotion_coupons.expires",
         "custom_code": "Anpassad kod",
         "enter_custom_code": "Ange anpassad kod",
-        "all_coupons": "Visa alla kuponger & kampanjer"
+        "all_coupons": "Visa alla kuponger & kampanjer",
+        "apply_aria": "Apply coupon {code}",
+        "remove_aria": "Remove coupon"
       }
     },
     "catalog": {

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -681,7 +681,9 @@
         "expires": "@:shared.account.promotion_coupons.expires",
         "custom_code": "自定义代码",
         "enter_custom_code": "输入自定义代码",
-        "all_coupons": "查看所有优惠券和促销活动"
+        "all_coupons": "查看所有优惠券和促销活动",
+        "apply_aria": "Apply coupon {code}",
+        "remove_aria": "Remove coupon"
       }
     },
     "catalog": {


### PR DESCRIPTION
## Description

## References
### Jira-link:
<!-- Put link to your task in Jira here -->
https://virtocommerce.atlassian.net/browse/VCST-5017
https://virtocommerce.atlassian.net/browse/VCST-5018
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.50.0-pr-2303-cc2d-cc2ddcdb.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only accessibility and copy changes in the coupon card; no checkout, auth, or API behavior changes.
> 
> **Overview**
> Improves **accessibility** on the cart **coupon card**: coupon validation errors are exposed with **`role="alert"`**, and the icon-only apply/remove actions get **translated `aria-label`s** tied to the current coupon code.
> 
> **`coupon-card.vue`** now builds **`viewConfig` in a computed** (instead of a static map) so apply labels include the live **`{code}`** via `useI18n`. Button config gains **`ariaLabel`**, passed through to **`VcButton`**.
> 
> Locale files add **`shared.cart.coupons_section.apply_aria`** and **`remove_aria`** across languages; most locales use English placeholder strings, while **`ru.json`** is fully localized.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc2ddcdbc94c81b2420ef9a937b5c47dc4940149. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->