### PR TITLE
fix(VCST-5124): vc-line-item for deleted products

### DIFF
--- a/client-app/ui-kit/components/molecules/line-item/vc-line-item.vue
+++ b/client-app/ui-kit/components/molecules/line-item/vc-line-item.vue
@@ -26,7 +26,7 @@
         @change="$emit('select', isSelected)"
       />
 
-      <div v-if="$slots['after-image'] || withImage" class="vc-line-item__img-container">
+      <div v-if="hasImageContainer" class="vc-line-item__img-container">
         <!--  IMAGE -->
         <VcImage class="vc-line-item__img" :src="imageUrl" :alt="name" size-suffix="sm" lazy />
 
@@ -39,8 +39,8 @@
         :class="[
           'vc-line-item__content',
           {
-            'vc-line-item__content--with-image': withImage,
-            'vc-line-item__content--selectable': !withImage && selectable,
+            'vc-line-item__content--with-image': hasImageContainer,
+            'vc-line-item__content--selectable': !hasImageContainer && selectable,
           },
         ]"
       >
@@ -143,7 +143,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watchEffect } from "vue";
+import { computed, ref, useSlots, watchEffect } from "vue";
 import type { CommonVendor, MoneyType, Property } from "@/core/api/graphql/types";
 import type { RouteLocationRaw } from "vue-router";
 
@@ -182,6 +182,10 @@ const props = withDefaults(defineProps<IProps>(), {
   properties: () => [],
   browserTarget: "_blank",
 });
+
+const slots = useSlots();
+
+const hasImageContainer = computed(() => !!slots["after-image"] || props.withImage);
 
 const isSelected = ref<boolean>(true);
 
@@ -316,6 +320,10 @@ watchEffect(() => {
     @container (width > theme("containers.2xl")) {
       @apply hidden;
     }
+
+    #{$deleted} & {
+      @apply hidden;
+    }
   }
 
   &__content {
@@ -356,6 +364,10 @@ watchEffect(() => {
 
   &__name-actions {
     @container (width <= theme("containers.2xl")) {
+      @apply hidden;
+    }
+
+    #{$deleted} & {
       @apply hidden;
     }
   }


### PR DESCRIPTION
## Description

## References
### Jira-link:
<!-- Put link to your task in Jira here -->
https://virtocommerce.atlassian.net/browse/VCST-5124
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.50.0-pr-2304-0326-0326b7d3.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UI-kit styling and template logic in vc-line-item with no auth, API, or data-flow changes.
> 
> **Overview**
> Improves **deleted** line-item presentation in `vc-line-item` by centralizing when the image column shows and tightening which action areas stay visible.
> 
> A new `hasImageContainer` computed (from `withImage` or the `after-image` slot) replaces inline template checks so layout classes stay consistent with that logic. When `deleted` is set, **after-image** and **after-title** action regions are hidden at all breakpoints (not only on small screens), so removed products don’t show extra controls beside the dimmed image/title.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0326b7d3eed6f80d974ec3fe4356878458f26844. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->