### PR TITLE
feat(VCST-2925): add data-test-id attributes to wishlist components

### DIFF
--- a/client-app/pages/account/list-details.vue
+++ b/client-app/pages/account/list-details.vue
@@ -16,6 +16,7 @@
 
         <div class="order-last mt-8 flex flex-wrap gap-3 md:ms-0 md:mt-0 md:shrink-0 lg:my-0">
           <VcButton
+            data-test-id="add-all-to-cart-button"
             :disabled="loading || !pagedListItems.length"
             size="sm"
             variant="outline"

--- a/client-app/pages/account/lists.vue
+++ b/client-app/pages/account/lists.vue
@@ -8,6 +8,7 @@
 
       <VcButton
         v-if="lists.length || loading"
+        data-test-id="create-wishlist-button"
         :disabled="creationButtonDisabled"
         size="sm"
         variant="outline"
@@ -46,7 +47,7 @@
     <!-- Empty -->
     <VcEmptyView v-else :text="$t('pages.account.lists.no_lists')" icon="outline-lists">
       <template #button>
-        <VcButton prepend-icon="plus" @click="openCreateListModal">
+        <VcButton data-test-id="create-wishlist-button" prepend-icon="plus" @click="openCreateListModal">
           {{ $t("pages.account.lists.create_list_button") }}
         </VcButton>
       </template>

--- a/client-app/shared/wishlists/components/add-or-update-wishlist-modal.vue
+++ b/client-app/shared/wishlists/components/add-or-update-wishlist-modal.vue
@@ -7,10 +7,12 @@
     "
     dividers
     is-mobile-fullscreen
+    test-id="add-or-update-wishlist-modal"
   >
     <div class="space-y-4">
       <VcInput
         v-model="name"
+        test-id-input="wishlist-name-input"
         :label="$t('shared.wishlists.add_or_update_wishlist_modal.list_name_label')"
         :placeholder="$t('shared.wishlists.add_or_update_wishlist_modal.list_name_placeholder')"
         :disabled="loading"
@@ -21,6 +23,7 @@
 
       <VcTextarea
         v-model="description"
+        data-test-id="wishlist-description-input"
         :label="$t('common.labels.description')"
         :disabled="loading"
         :message="errors.description"
@@ -33,6 +36,7 @@
       <div v-if="isCorporateMember" class="space-y-4">
         <VcSelect
           v-model="sharingScope"
+          test-id-dropdown="wishlist-sharing-scope-select"
           :label="$t('shared.wishlists.add_or_update_wishlist_modal.sharing_scope_label')"
           :placeholder="$t('shared.wishlists.add_or_update_wishlist_modal.sharing_scope_placeholder')"
           :disabled="loading"
@@ -67,7 +71,13 @@
         {{ $t("shared.wishlists.add_or_update_wishlist_modal.cancel_button") }}
       </VcButton>
 
-      <VcButton :loading="loading" :disabled="!canSave" class="ms-auto" @click="save(close)">
+      <VcButton
+        data-test-id="wishlist-settings-save-button"
+        :loading="loading"
+        :disabled="!canSave"
+        class="ms-auto"
+        @click="save(close)"
+      >
         {{
           isEditMode
             ? $t("shared.wishlists.add_or_update_wishlist_modal.save_button")

--- a/client-app/shared/wishlists/components/add-to-list.vue
+++ b/client-app/shared/wishlists/components/add-to-list.vue
@@ -1,5 +1,6 @@
 <template>
   <VcProductActionsButton
+    data-test-id="add-to-list-button"
     color="danger"
     :icon-size="iconSize"
     :active="localWishlistStatus"

--- a/client-app/shared/wishlists/components/add-to-wishlists-modal.vue
+++ b/client-app/shared/wishlists/components/add-to-wishlists-modal.vue
@@ -1,5 +1,11 @@
 <template>
-  <VcModal :title="$t('shared.wishlists.add_to_wishlists_modal.title')" max-width="50rem" is-mobile-fullscreen dividers>
+  <VcModal
+    :title="$t('shared.wishlists.add_to_wishlists_modal.title')"
+    max-width="50rem"
+    is-mobile-fullscreen
+    dividers
+    test-id="add-to-wishlists-modal"
+  >
     <div class="rounded border" id="add-to-wishlists-modal">
       <!-- Lists -->
       <template v-if="!loadingLists">
@@ -18,6 +24,7 @@
                 :model-value="!removedLists.includes(list.id || '')"
                 :value="list.id"
                 :disabled="loading"
+                :test-id="`wishlist-modal-list-with-product-checkbox-${list.id}`"
                 class="grow"
                 @update:model-value="listsRemoveUpdate(list.id || '', !!$event)"
               >
@@ -86,7 +93,12 @@
         <VcCheckboxGroup v-model="selectedListsOtherIds">
           <transition-group name="list-input" tag="ul">
             <li v-for="list in listsOther" :key="list.id" class="flex justify-between px-6 pb-5 last:pb-5 sm:pb-4">
-              <VcCheckbox :value="list.id" :disabled="loading" class="grow">
+              <VcCheckbox
+                :value="list.id"
+                :disabled="loading"
+                :test-id="`wishlist-modal-list-checkbox-${list.id}`"
+                class="grow"
+              >
                 <span
                   class="line-clamp-1 ps-0.5 text-base"
                   :class="{ 'text-neutral': !selectedListsOtherIds.includes(list.id!) }"
@@ -127,6 +139,7 @@
       </VcButton>
 
       <VcButton
+        data-test-id="wishlist-modal-save-button"
         :loading="loading"
         :disabled="!newLists.length && !selectedListsOtherIds.length && !removedLists.length"
         class="ms-auto"

--- a/client-app/shared/wishlists/components/delete-wishlist-modal.vue
+++ b/client-app/shared/wishlists/components/delete-wishlist-modal.vue
@@ -1,5 +1,10 @@
 <template>
-  <VcModal :title="$t('shared.wishlists.delete_wishlist_modal.title')" variant="danger" icon="warning">
+  <VcModal
+    :title="$t('shared.wishlists.delete_wishlist_modal.title')"
+    variant="danger"
+    icon="warning"
+    test-id="delete-wishlist-modal"
+  >
     <i18n-t keypath="shared.wishlists.delete_wishlist_modal.message" tag="p" scope="global">
       <template #listName>
         <span class="font-black">{{ list.name }}</span>
@@ -7,7 +12,7 @@
     </i18n-t>
 
     <template #actions="{ close }">
-      <VcButton :loading="loading" color="danger" @click="remove(close)">
+      <VcButton data-test-id="delete-button" :loading="loading" color="danger" @click="remove(close)">
         {{ $t("shared.wishlists.delete_wishlist_modal.delete_button") }}
       </VcButton>
 

--- a/client-app/shared/wishlists/components/wishlist-card.vue
+++ b/client-app/shared/wishlists/components/wishlist-card.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="wishlist-card">
+  <div class="wishlist-card" data-test-id="wishlist-card">
     <div class="wishlist-card__title-row">
       <router-link :to="{ name: 'ListDetails', params: { listId: list.id } }" class="wishlist-card__title">
         {{ list.name }}

--- a/client-app/shared/wishlists/components/wishlist-dropdown-menu.vue
+++ b/client-app/shared/wishlists/components/wishlist-dropdown-menu.vue
@@ -1,11 +1,18 @@
 <template>
   <VcDropdownMenu :y-offset="4" :x-offset="0" placement="bottom-end">
     <template #trigger="{ triggerProps }">
-      <VcButton icon="cog" color="secondary" variant="outline" size="xs" v-bind="triggerProps" />
+      <VcButton
+        data-test-id="wishlist-card-menu-button"
+        icon="cog"
+        color="secondary"
+        variant="outline"
+        size="xs"
+        v-bind="triggerProps"
+      />
     </template>
 
     <template #content>
-      <VcMenuItem color="secondary" nowrap @click="$emit('edit')">
+      <VcMenuItem data-test-id="wishlist-card-edit-menu-item" color="secondary" nowrap @click="$emit('edit')">
         <template #prepend>
           <VcIcon name="edit" />
         </template>
@@ -13,7 +20,7 @@
         <span>{{ $t("shared.wishlists.list_card.list_edit_button") }}</span>
       </VcMenuItem>
 
-      <VcMenuItem color="secondary" nowrap @click="$emit('remove')">
+      <VcMenuItem data-test-id="wishlist-card-remove-menu-item" color="secondary" nowrap @click="$emit('remove')">
         <VcIcon name="delete-2" class="fill-danger" />
 
         <span>{{ $t("shared.wishlists.list_card.remove_list_button") }}</span>


### PR DESCRIPTION
## Description
Added stable `data-test-id` hooks for wishlist E2E automation.

## Changes

- Added test selectors for wishlist creation from account lists page.
- Added test selectors for wishlist settings modal:
  - name input
  - description input
  - sharing scope selector
  - save button
- Added test selectors for add-to-wishlists modal:
  - modal root
  - wishlist checkboxes
  - wishlist-with-product checkboxes
  - save button
- Added selectors for wishlist delete modal.
- Added selector for add-to-list button on product cards/PDP.
- Added selector for wishlist card menu actions.
- Added selector for add-all-to-cart action on wishlist details page.

## Notes

No business logic changes. The frontend changes are limited to stable automation hooks.

## References
### Jira-link:
<!-- Put link to your task in Jira here -->
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.50.0-pr-2307-04f6-04f60731.zip