### PR TITLE
feat(VCST-4492): test new workflow versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,6 @@ on:
 
 jobs:
   release:
-    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.35
+    uses: VirtoCommerce/.github/.github/workflows/release.yml@VCST-4492 #v3.800.35
     secrets:
       envPAT: ${{ secrets.REPO_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,6 @@ on:
 
 jobs:
   release:
-    uses: VirtoCommerce/.github/.github/workflows/release.yml@VCST-4492 #v3.800.35
+    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.38
     secrets:
       envPAT: ${{ secrets.REPO_TOKEN }}

--- a/.github/workflows/theme-ci.yml
+++ b/.github/workflows/theme-ci.yml
@@ -251,7 +251,7 @@ jobs:
     needs: ci
     if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
         (github.event_name == 'workflow_dispatch') || (github.base_ref == 'dev') && (github.event_name == 'pull_request') }}
-    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@VCST-4492 #v3.800.35
+    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.38
     with:
       installModules: 'false'
       installCustomModule: 'false'

--- a/.github/workflows/theme-ci.yml
+++ b/.github/workflows/theme-ci.yml
@@ -251,7 +251,7 @@ jobs:
     needs: ci
     if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
         (github.event_name == 'workflow_dispatch') || (github.base_ref == 'dev') && (github.event_name == 'pull_request') }}
-    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.35
+    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@VCST-4492 #v3.800.35
     with:
       installModules: 'false'
       installCustomModule: 'false'

--- a/backend-packages.json
+++ b/backend-packages.json
@@ -1,8 +1,8 @@
 {
   "ManifestVersion": "2.0",
-  "PlatformVersion": "3.1035.0",
+  "PlatformVersion": "3.1032.0",
   "PlatformImage": "ghcr.io/virtocommerce/platform",
-  "PlatformImageTag": "3.1035.0",
+  "PlatformImageTag": "3.1032.0",
   "PlatformAssetUrl": "",
   "Sources": [
     {

--- a/backend-packages.json
+++ b/backend-packages.json
@@ -1,8 +1,8 @@
 {
   "ManifestVersion": "2.0",
-  "PlatformVersion": "3.1032.0",
+  "PlatformVersion": "3.1035.0-pr-3051-23c3-vcst-5212-23c309b0", //3.102.0
   "PlatformImage": "ghcr.io/virtocommerce/platform",
-  "PlatformImageTag": "3.1032.0",
+  "PlatformImageTag": "3.1035.0-pr-3051-23c3-vcst-5212-23c309b0",
   "PlatformAssetUrl": "",
   "Sources": [
     {

--- a/backend-packages.json
+++ b/backend-packages.json
@@ -1,6 +1,6 @@
 {
   "ManifestVersion": "2.0",
-  "PlatformVersion": "3.1035.0-pr-3051-23c3-vcst-5212-23c309b0", //3.102.0
+  "PlatformVersion": "3.1035.0-pr-3051-23c3-vcst-5212-23c309b0",
   "PlatformImage": "ghcr.io/virtocommerce/platform",
   "PlatformImageTag": "3.1035.0-pr-3051-23c3-vcst-5212-23c309b0",
   "PlatformAssetUrl": "",

--- a/backend-packages.json
+++ b/backend-packages.json
@@ -1,8 +1,8 @@
 {
   "ManifestVersion": "2.0",
-  "PlatformVersion": "3.1035.0-pr-3051-23c3-vcst-5212-23c309b0",
+  "PlatformVersion": "3.1035.0",
   "PlatformImage": "ghcr.io/virtocommerce/platform",
-  "PlatformImageTag": "3.1035.0-pr-3051-23c3-vcst-5212-23c309b0",
+  "PlatformImageTag": "3.1035.0",
   "PlatformAssetUrl": "",
   "Sources": [
     {


### PR DESCRIPTION
## Description

## References
### Jira-link:
<!-- Put link to your task in Jira here -->https://virtocommerce.atlassian.net/browse/VCST-4492
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.51.0-pr-2319-442b-442bb7b0.zip


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only version pin updates with no runtime or application logic changes.
> 
> **Overview**
> Bumps reusable GitHub Actions workflow pins from **v3.800.35** to **v3.800.38** in two places: the **Release** workflow (`release.yml`) and the **Theme CI** `auto-tests` job (`theme-ci.yml`), which calls the shared **pytest-tests** workflow.
> 
> No application or theme code changes—only CI/release orchestration to exercise the newer shared workflow versions (VCST-4492).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 442bb7b0858cb840b9b14eeeb0a4cd833b0a6b08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->