### PR TITLE
feat(ui-kit): forward lazy prop through VcSelect and VcDropdownMenu

### DIFF
--- a/client-app/ui-kit/components/molecules/dropdown-menu/vc-dropdown-menu.vue
+++ b/client-app/ui-kit/components/molecules/dropdown-menu/vc-dropdown-menu.vue
@@ -11,6 +11,7 @@
     :offset-options="offsetOptions"
     :z-index="zIndex"
     :disabled="disabled"
+    :lazy="lazy"
     shadow
     @toggle="$emit('toggle', $event)"
   >
@@ -61,6 +62,8 @@ interface IProps {
   listRole?: string;
   listId?: string;
   listLabel?: string;
+  /** Defer rendering menu content until the menu is first opened (forwarded to VcPopover). */
+  lazy?: boolean;
 }
 
 defineEmits<IEmits>();

--- a/client-app/ui-kit/components/molecules/select/vc-select.vue
+++ b/client-app/ui-kit/components/molecules/select/vc-select.vue
@@ -19,6 +19,7 @@
     <VcDropdownMenu
       class="vc-select__container"
       :disabled="!enabled"
+      :lazy="lazy"
       :data-test-id="testIdDropdown"
       tabindex="-1"
       width="trigger"
@@ -197,6 +198,8 @@ interface IProps {
   clearable?: boolean;
   testIdDropdown?: string;
   enableTeleport?: boolean;
+  /** Defer rendering the option list until the dropdown is first opened (forwarded to VcPopover). */
+  lazy?: boolean;
 }
 
 interface IEmits {


### PR DESCRIPTION
## What

Forward the existing `lazy` prop from `VcPopover` up through `VcDropdownMenu` and `VcSelect`, so a select can defer rendering its option list until the dropdown is first opened.

## Why

#2123 added `lazy` to `VcPopover` (`shouldRenderContent = !lazy || hasBeenOpened`), but `VcSelect`/`VcDropdownMenu` never exposed it, so no select can use it. By default `VcSelect` mounts its **entire** option list into the DOM on mount -- the popover only hides the content with `display:none`, it does not defer mounting it.

**Concrete cost** (measured on a product-configurator card in a downstream app):

- **50** `VcSelect`s on one card, **~35 options each** -> **~1,756** `<li role="option">` elements (**~5,000 DOM nodes** including the per-option value/label spans) mounted **while every dropdown is closed**.
- The screen commonly shows **2+ such cards** -> **~3,500 options / ~10,000 DOM nodes** sitting in the DOM.

Most of those dropdowns are never opened, so for the common case this DOM is pure overhead: it inflates the initial render and memory footprint, and it is reconciled (diffed) on every update of the surrounding view -- all for content the user never sees. (The nodes themselves are reused by the diff, so this is mount + reconciliation cost, not DOM re-creation.)

**With `lazy`:** a closed select renders **0** option nodes (only the trigger button is in the DOM); its ~35 options mount **only when it is first opened**. ~1,756 -> ~0 option nodes per card while idle.

## How

Add an optional `lazy?: boolean` to `VcSelect` and `VcDropdownMenu`, passed straight through to `VcPopover`. **Default is unchanged (eager)** -- purely additive; no existing consumer is affected unless it opts in with `lazy`.

```vue
<VcSelect :items="items" lazy />
```

## Testing

- `<VcSelect lazy>`: no option `<li>`s exist in the DOM until the dropdown is opened the first time; behaves normally afterwards.
- `<VcSelect>` (no prop): unchanged -- options render eagerly as before.
