### PR TITLE
perf: exclude generated GraphQL types from Tailwind content scan

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -171,7 +171,15 @@ const colorSet = {
 };
 
 module.exports = {
-  content: ["./index.html", "./client-app/**/*.{vue,js,ts,jsx,tsx}", "./node_modules/tw-elements/dist/js/**/*.js"],
+  content: [
+    "./index.html",
+    "./client-app/**/*.{vue,js,ts,jsx,tsx}",
+    // Generated GraphQL types (1+ MiB, 25k-char lines) trigger catastrophic backtracking in the
+    // Tailwind class extractor regex, adding tens of seconds to every cold dev start and build.
+    // Codegen output cannot contain real class names.
+    "!./client-app/**/api/graphql/**/types.ts",
+    "./node_modules/tw-elements/dist/js/**/*.js",
+  ],
 
   safelist: ["lg:inline"],
 


### PR DESCRIPTION
## What

One-line fix in `tailwind.config.ts`: exclude generated GraphQL types (`client-app/**/api/graphql/**/types.ts`) from Tailwind's `content` scan.

## Results (measured on this repo, stock `dev` vs this branch)

| Metric | Before | After | Faster by |
|---|---|---|---|
| `yarn dev` -> first page render | 44-46 s | 16-21 s | **~-60% (~2.5x)** |
| `yarn dev` -> page rendered, total incl. server boot | 47-49 s | 19-24 s | **~-58%** |
| `yarn build-only` (production build) | 62 s | 34 s | **-45% (~1.9x)** |
| Tailwind extractor on `types.ts` alone (isolated) | 16.5 s | 0 s (excluded) | - |

Measurement protocol: cold conditions enforced before every run (`node_modules/.vite` wiped, OS page cache evicted via `posix_fadvise` over node_modules + sources), first page render driven by headless Chromium with an empty browser cache, 2 runs per variant, 6-core Linux machine, backend `virtostart-demo-admin.govirto.com`.

## Why

Tailwind 3's class-extractor regex backtracks catastrophically on `client-app/core/api/graphql/types.ts` - 1.3 MiB of GraphQL codegen output with lines up to 25k characters: 16.5 s of pure regex per cold PostCSS context, paid on every cold dev start and again during builds. It is most of the gap between Vite's instant "ready" message and the first page actually rendering.

Downstream forks pay proportionally more as their schema grows: in ours, with a 3 MiB `types.ts`, the scan cost 72 s and CPU profiling showed 73 of 77 seconds of Tailwind JIT init inside this single extractor regex on this single file (all other ~1500 content files combined: 1.4 s). After the exclusion our cold dev start dropped 163 s -> 23 s.

Codegen output cannot contain real Tailwind class names, so scanning it is pure waste.

## How

Added a negation pattern `!./client-app/**/api/graphql/**/types.ts` to the `content` array, with a comment explaining the constraint. Negation is supported by fast-glob, which Tailwind 3 uses for content resolution; the pattern also covers the module-level generated files (`client-app/modules/*/api/graphql/types.ts`) and any future modules automatically.

## Test plan

- [x] Cold dev start measured on this repo before/after (protocol above): 44-46 s -> 16-21 s
- [x] Production build measured on this repo before/after: 62 s -> 34 s
- [x] Generated CSS verified identical with and without the exclusion (selector-level diff of the Tailwind output: zero selectors lost, zero gained)
- [ ] Reviewer: start the dev server cold and compare time to first rendered page

🤖 Generated with [Claude Code](https://claude.com/claude-code)
