### PR TITLE
feat(ui-kit): forward teleportSelector prop through VcSelect and VcDropdownMenu

### DIFF
--- a/client-app/ui-kit/components/molecules/dropdown-menu/vc-dropdown-menu.vue
+++ b/client-app/ui-kit/components/molecules/dropdown-menu/vc-dropdown-menu.vue
@@ -12,6 +12,7 @@
     :z-index="zIndex"
     :disabled="disabled"
     :lazy="lazy"
+    :teleport-selector="teleportSelector"
     shadow
     @toggle="$emit('toggle', $event)"
   >
@@ -64,6 +65,8 @@ interface IProps {
   listLabel?: string;
   /** Defer rendering menu content until the menu is first opened (forwarded to VcPopover). */
   lazy?: boolean;
+  /** Teleport target selector for the menu content; defaults to the global popover host (forwarded to VcPopover). */
+  teleportSelector?: string;
 }
 
 defineEmits<IEmits>();

--- a/client-app/ui-kit/components/molecules/select/vc-select.vue
+++ b/client-app/ui-kit/components/molecules/select/vc-select.vue
@@ -20,6 +20,7 @@
       class="vc-select__container"
       :disabled="!enabled"
       :lazy="lazy"
+      :teleport-selector="teleportSelector"
       :data-test-id="testIdDropdown"
       tabindex="-1"
       width="trigger"
@@ -200,6 +201,8 @@ interface IProps {
   enableTeleport?: boolean;
   /** Defer rendering the option list until the dropdown is first opened (forwarded to VcPopover). */
   lazy?: boolean;
+  /** Teleport target selector for the dropdown; defaults to the global popover host (forwarded to VcPopover). */
+  teleportSelector?: string;
 }
 
 interface IEmits {


### PR DESCRIPTION
## What

Forward the existing `teleportSelector` prop from `VcPopover` up through `VcDropdownMenu` and `VcSelect`, so a select can teleport its dropdown to a custom host instead of always the global popover host.

## Why

`VcPopover` already supports `teleportSelector` (default `[id='popover-host']`), but `VcSelect`/`VcDropdownMenu` never exposed it, so a teleported select dropdown can *only* land in the global `#popover-host`. That host is intentionally high in the stacking order (so dropdowns opened inside modals stay above the modal), which means an in-page select whose dropdown teleports there renders **above** a sticky header.

Concrete case (downstream app): a configuration matrix wraps its `VcSelect`s in `overflow-hidden` / `overflow-x-auto` containers, so the dropdown must teleport to escape clipping. With the only available target being the global high-z host, the open options paint **over** the page's sticky header while scrolling, instead of sliding under it.

A global z-index change can't fix this without breaking modal stacking (`modal > header` but `dropdown-in-modal > modal`, while we also want `header > in-page-dropdown` -- circular). The clean fix is to let the consumer point the dropdown at a page-local host that sits below the header, which only requires `VcSelect`/`VcDropdownMenu` to forward the prop `VcPopover` already has.

## How

Add an optional `teleportSelector?: string` to `VcSelect` and `VcDropdownMenu`, passed straight through to `VcPopover`. **Default is unchanged (global popover host)** -- purely additive; no existing consumer is affected unless it opts in.

```vue
<VcSelect :items="items" enable-teleport teleport-selector="[id='my-local-host']" />
```

This mirrors the `lazy` passthrough added in #2322.

## Testing

- `<VcSelect enable-teleport teleport-selector="#my-host">`: the dropdown content teleports into `#my-host` instead of the global popover host.
- `<VcSelect enable-teleport>` (no prop): unchanged -- still teleports to the global `#popover-host`.
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.51.0-pr-2332-be64-be64e456.zip