### PR TITLE
VCST-5344: Fix per-brand CVV length validation in shared bank-card form

### DIFF
--- a/client-app/shared/payment/components/bank-card-form.test.ts
+++ b/client-app/shared/payment/components/bank-card-form.test.ts
@@ -24,10 +24,13 @@ vi.mock("vue-i18n", () => {
 
 const CARD_NUMBER_LABEL = "shared.payment.bank_card_form.number_label";
 const EXPIRATION_FIELD_LABEL = "shared.payment.bank_card_form.expiration_date_label";
+const SECURITY_CODE_LABEL = "shared.payment.bank_card_form.security_code_label";
 const ERROR_MESSAGES = {
   MONTH: "shared.payment.bank_card_form.errors.month",
   MONTH_INCOMPLETE: "shared.payment.bank_card_form.month_label must be exactly 2 characters",
   YEAR_INCOMPLETE: "shared.payment.bank_card_form.year_label must be exactly 2 characters",
+  CVV_3: "shared.payment.bank_card_form.security_code_label must be exactly 3 characters",
+  CVV_4: "shared.payment.bank_card_form.security_code_label must be exactly 4 characters",
 } as const;
 
 async function findElementByText(text: string) {
@@ -41,6 +44,9 @@ function getExpirationInput() {
 }
 function getCardNumberInput() {
   return renderedComponent.getByLabelText<HTMLInputElement>(CARD_NUMBER_LABEL);
+}
+function getSecurityCodeInput() {
+  return renderedComponent.getByLabelText<HTMLInputElement>(SECURITY_CODE_LABEL);
 }
 
 async function waitForElementToBeRemoved(selector: string) {
@@ -203,6 +209,51 @@ describe("BankCardForm", () => {
         await fireEvent.update(input, "122");
         expect(await findElementByText(ERROR_MESSAGES.YEAR_INCOMPLETE)).toBeInTheDocument();
       });
+    });
+  });
+
+  // VCST-5344: the CVV length must be validated per detected card brand. Amex (IIN prefix 34/37)
+  // requires a 4-digit CVV; all other brands require exactly 3. The previous brand-agnostic rule
+  // (min 3 / max 4) accepted both lengths for any brand, letting a malformed CVV enable Place order
+  // and create an unpaid ghost order before Accept.js rejected it downstream. The brand detection +
+  // length decision are shared with the Skyflow form via shared/payment/utils/cvv-validation.
+  describe("Security Code Field (per-brand CVV)", () => {
+    const AMEX_NUMBER = "370000000000002";
+    const VISA_NUMBER = "4007000000027";
+
+    async function fillBrandAndCvv(cardNumber: string, cvv: string) {
+      await fireEvent.update(getCardNumberInput(), cardNumber);
+      await fireEvent.update(getSecurityCodeInput(), cvv);
+    }
+
+    it("should reject a 3-digit CVV on an Amex card (needs 4)", async () => {
+      await fillBrandAndCvv(AMEX_NUMBER, "123");
+      expect(await findElementByText(ERROR_MESSAGES.CVV_4)).toBeInTheDocument();
+    });
+
+    it("should clamp the CVV mask to 3 digits on a Visa card (cannot over-type a 4-digit CVV)", async () => {
+      const cvvInput = getSecurityCodeInput();
+      await fireEvent.update(getCardNumberInput(), VISA_NUMBER);
+      await fireEvent.update(cvvInput, "1234");
+      // The brand-conditional mask truncates the 4th digit so a Visa CVV can never exceed 3.
+      expect(cvvInput.value).toBe("123");
+    });
+
+    it("should reject a 2-digit CVV on a Visa card (needs exactly 3)", async () => {
+      await fillBrandAndCvv(VISA_NUMBER, "12");
+      expect(await findElementByText(ERROR_MESSAGES.CVV_3)).toBeInTheDocument();
+    });
+
+    it("should accept a 4-digit CVV on an Amex card", async () => {
+      await fillBrandAndCvv(AMEX_NUMBER, "1234");
+      expect(queryElementByText(ERROR_MESSAGES.CVV_3)).not.toBeInTheDocument();
+      expect(queryElementByText(ERROR_MESSAGES.CVV_4)).not.toBeInTheDocument();
+    });
+
+    it("should accept a 3-digit CVV on a Visa card", async () => {
+      await fillBrandAndCvv(VISA_NUMBER, "123");
+      expect(queryElementByText(ERROR_MESSAGES.CVV_3)).not.toBeInTheDocument();
+      expect(queryElementByText(ERROR_MESSAGES.CVV_4)).not.toBeInTheDocument();
     });
   });
 });

--- a/client-app/shared/payment/components/bank-card-form.vue
+++ b/client-app/shared/payment/components/bank-card-form.vue
@@ -57,11 +57,11 @@
         :readonly="readonly"
         :disabled="disabled"
         type="password"
-        placeholder="111"
+        :placeholder="securityCodePlaceholder"
         name="securityCode"
         autocomplete="off"
-        minlength="3"
-        maxlength="4"
+        :minlength="securityCodeLength"
+        :maxlength="securityCodeLength"
         class="basis-1/4"
         hide-password-switcher
         required
@@ -82,6 +82,7 @@ import { computed, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import * as yup from "yup";
 import { isExpirationDateValid } from "@/core/utilities/date";
+import { getCardSchemeFromNumber, getCvvLength } from "@/shared/payment/utils/cvv-validation";
 import type { BankCardErrorsType, BankCardType } from "@/shared/payment";
 
 const emit = defineEmits<IEmits>();
@@ -115,10 +116,16 @@ const initialValues: BankCardType = {
 
 const cardMaskOptions = { mask: "#### #### #### #### ###" };
 const dateMaskOptions = { mask: "## / ##" };
-const securityCodeMaskOptions = { mask: "####" };
 
 const cardMask = new Mask(cardMaskOptions);
 const dateMask = new Mask(dateMaskOptions);
+
+// American Express (IIN prefix 34/37) uses a 4-digit CVV; every other brand uses 3. Deriving the
+// required length from the entered card number lets the CVV rule + mask + length + placeholder
+// reflect the detected brand, so a malformed CVV is caught client-side (gating cart "Create order")
+// instead of only later during Accept.js tokenization, after an unpaid order already exists.
+// The brand detection + length decision are shared with the Skyflow form via shared/payment/utils.
+const cvvLengthForNumber = (cardNumber?: string | null) => getCvvLength(getCardSchemeFromNumber(cardNumber));
 
 const labels = computed(() => {
   return {
@@ -158,7 +165,11 @@ const validationSchema = toTypedSchema(
             .label(labels.value.yearLabel)
         : schema;
     }),
-    securityCode: yup.string().required().min(3).max(4).label(labels.value.securityCode),
+    securityCode: yup
+      .string()
+      .required()
+      .when("number", ([cardNumber], schema) => schema.length(cvvLengthForNumber(cardNumber)))
+      .label(labels.value.securityCode),
   }),
 );
 
@@ -177,6 +188,10 @@ const [cardholderName] = defineField("cardholderName");
 const [month] = defineField("month");
 const [year] = defineField("year");
 const [securityCode] = defineField("securityCode");
+
+const securityCodeLength = computed(() => cvvLengthForNumber(number.value));
+const securityCodeMaskOptions = computed(() => ({ mask: "#".repeat(securityCodeLength.value) }));
+const securityCodePlaceholder = computed(() => "1".repeat(securityCodeLength.value));
 
 const expirationDate = computed<string | undefined, string>({
   get: () => dateMask.masked((month.value || "") + (year.value || "")),

--- a/client-app/shared/payment/utils/cvv-validation.test.ts
+++ b/client-app/shared/payment/utils/cvv-validation.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import {
+  AMEX_CVV_LENGTH,
+  DEFAULT_CVV_LENGTH,
+  getCardSchemeFromNumber,
+  getCvvLength,
+  isAmexScheme,
+} from "./cvv-validation";
+
+// Shared per-brand CVV length core (VCST-5344 / VCST-5202). American Express requires a 4-digit
+// CVV; every other (or not-yet-detected) brand requires exactly 3. Both card forms derive their
+// rule/mask/length from this single decision, so a malformed CVV is rejected client-side instead
+// of enabling Place order and producing a processor decline / unpaid ghost order.
+describe("getCvvLength", () => {
+  it("requires 4 digits for American Express", () => {
+    expect(getCvvLength("AMEX")).toBe(AMEX_CVV_LENGTH);
+  });
+
+  it("requires 3 digits for non-Amex brands", () => {
+    for (const scheme of ["VISA", "MASTERCARD", "DISCOVER"]) {
+      expect(getCvvLength(scheme)).toBe(DEFAULT_CVV_LENGTH);
+    }
+  });
+
+  it("defaults to 3 digits when the brand is not yet detected", () => {
+    expect(getCvvLength()).toBe(DEFAULT_CVV_LENGTH);
+    expect(getCvvLength(null)).toBe(DEFAULT_CVV_LENGTH);
+    expect(getCvvLength("")).toBe(DEFAULT_CVV_LENGTH);
+  });
+});
+
+// The two data sources spell Amex differently: the Skyflow SDK enum uses "AMEX"; the Skyflow vault
+// (surfaced by the backend) uses the full network name "AMERICAN EXPRESS". Both — in any casing —
+// must resolve to Amex.
+describe("isAmexScheme", () => {
+  it("matches every Amex spelling the SDK and the vault emit, case-insensitively", () => {
+    for (const scheme of ["AMEX", "amex", "American Express", "AMERICAN EXPRESS"]) {
+      expect(isAmexScheme(scheme)).toBe(true);
+    }
+  });
+
+  it("does not match other brands or an undetected brand", () => {
+    for (const scheme of ["VISA", "MASTERCARD", "DISCOVER", "", null, undefined]) {
+      expect(isAmexScheme(scheme)).toBe(false);
+    }
+  });
+});
+
+// The Authorize.Net bank-card form has no SDK, so it detects the brand from the typed card number's
+// IIN prefix. Only Amex (34/37) needs distinguishing; everything else falls back to the 3-digit rule.
+describe("getCardSchemeFromNumber", () => {
+  it("detects Amex from an Amex card number (IIN 34/37)", () => {
+    expect(getCardSchemeFromNumber("370000000000002")).toBe("AMEX"); // Amex test card (37)
+    expect(getCardSchemeFromNumber("341111111111111")).toBe("AMEX"); // Amex (34)
+    // Non-digit characters (spaces / mask chars) are stripped before matching.
+    expect(getCardSchemeFromNumber("3700 0000 0000 002")).toBe("AMEX");
+  });
+
+  it("returns undefined for non-Amex brands so the 3-digit default applies", () => {
+    expect(getCardSchemeFromNumber("4007000000027")).toBeUndefined(); // Visa
+    expect(getCardSchemeFromNumber("5555555555554444")).toBeUndefined(); // Mastercard
+  });
+
+  it("returns undefined while the prefix is still empty or incomplete", () => {
+    expect(getCardSchemeFromNumber("")).toBeUndefined();
+    expect(getCardSchemeFromNumber(null)).toBeUndefined();
+    expect(getCardSchemeFromNumber()).toBeUndefined();
+    expect(getCardSchemeFromNumber("3")).toBeUndefined(); // 34/37 not yet distinguishable
+  });
+
+  it("feeds getCvvLength to require 4 digits for a detected Amex card, 3 otherwise", () => {
+    expect(getCvvLength(getCardSchemeFromNumber("370000000000002"))).toBe(AMEX_CVV_LENGTH);
+    expect(getCvvLength(getCardSchemeFromNumber("4007000000027"))).toBe(DEFAULT_CVV_LENGTH);
+  });
+});

--- a/client-app/shared/payment/utils/cvv-validation.ts
+++ b/client-app/shared/payment/utils/cvv-validation.ts
@@ -1,0 +1,48 @@
+// Per-brand CVV (security code) length rules shared by every manual/embedded card form
+// (the Authorize.Net `bank-card-form`, the Skyflow form). American Express uses a 4-digit CVV
+// ("CID"); every other brand uses 3 digits. This module is the single source of truth for that
+// decision — each form derives the concrete artifacts it needs (a yup `.length()` rule, a maska
+// mask, `maxlength`, a `REGEX_MATCH_RULE` regex, a placeholder) from the one length returned here,
+// so the constants and the Amex rule are never duplicated per processor.
+
+export const AMEX_CVV_LENGTH = 4;
+export const DEFAULT_CVV_LENGTH = 3;
+
+/** Canonical Amex scheme token (matches `Skyflow.CardType.AMEX`). */
+export const AMEX_SCHEME = "AMEX";
+
+// Every string the card data sources emit for Amex, normalized to letters-only + uppercase:
+// the Skyflow SDK enum `Skyflow.CardType.AMEX` -> "AMEX"; the Skyflow vault `card_scheme`
+// (surfaced by the backend) -> "AMERICAN EXPRESS".
+const AMEX_SCHEME_ALIASES = new Set(["AMEX", "AMERICANEXPRESS"]);
+
+// Amex issuer identification numbers (IIN/BIN) start with 34 or 37.
+const AMEX_IIN_RE = /^3[47]/;
+
+/** True when the scheme name (in any casing/spelling the data sources emit) is American Express. */
+export function isAmexScheme(cardScheme?: string | null): boolean {
+  const normalized = (cardScheme ?? "").toUpperCase().replace(/[^A-Z]/g, "");
+  return AMEX_SCHEME_ALIASES.has(normalized);
+}
+
+/**
+ * Detects the card scheme from a (possibly partially masked) card number by its IIN prefix.
+ * Only Amex needs distinguishing (4-digit CVV), so this returns {@link AMEX_SCHEME} for an Amex
+ * prefix (34/37) and `undefined` otherwise. Non-digit characters (spaces, mask characters) are
+ * stripped first, so a masked value with the leading digits intact still resolves correctly.
+ */
+export function getCardSchemeFromNumber(cardNumber?: string | null): string | undefined {
+  const digits = (cardNumber ?? "").replace(/\D/g, "");
+  return AMEX_IIN_RE.test(digits) ? AMEX_SCHEME : undefined;
+}
+
+/**
+ * The required CVV length for a detected card scheme: Amex -> 4, every other (or unknown) -> 3.
+ *
+ * @param cardScheme the resolved scheme (from {@link getCardSchemeFromNumber}, the Skyflow CHANGE
+ *   event's `selectedCardScheme`, or a saved card's `cardScheme`/`cardType`), or undefined before
+ *   a brand is detected.
+ */
+export function getCvvLength(cardScheme?: string | null): number {
+  return isAmexScheme(cardScheme) ? AMEX_CVV_LENGTH : DEFAULT_CVV_LENGTH;
+}

--- a/client-app/shared/payment/utils/skyflow-cvv-validation.ts
+++ b/client-app/shared/payment/utils/skyflow-cvv-validation.ts
@@ -1,5 +1,7 @@
-// Per-brand CVV (security code) rules for the Skyflow card form.
-// American Express uses a 4-digit CVV (CID); all other brands use 3 digits.
+// Skyflow-specific CVV (security code) shaping. The per-brand length decision and the card-number
+// brand detection live in the shared `./cvv-validation` core (also consumed by the Authorize.Net
+// `bank-card-form`); this module only turns that length into the `{ regex, placeholder }` shape
+// Skyflow's REGEX_MATCH_RULE expects, and re-exports the shared detector for the Skyflow form.
 //
 // Resolving the brand differs by path:
 //   - New card: the Skyflow SDK exposes the brand on the CARD_NUMBER CHANGE event only as
@@ -10,20 +12,12 @@
 //     CARD_NUMBER `value` even in PROD: the first 6 for Amex, 8 for others).
 //   - Saved card: the brand comes from the GraphQL SkyflowCardType.cardScheme / cardType, which
 //     the backend passes through verbatim from the Skyflow vault. Those use full network names
-//     (e.g. "AMERICAN EXPRESS"), whereas the SDK enum uses "AMEX", so matching is normalized.
+//     (e.g. "AMERICAN EXPRESS"), whereas the SDK enum uses "AMEX", so matching is normalized
+//     inside the shared core.
 
-const AMEX_CVV_LENGTH = 4;
-const DEFAULT_CVV_LENGTH = 3;
+import { getCvvLength } from "./cvv-validation";
 
-/** Canonical Amex scheme token (matches Skyflow.CardType.AMEX). */
-const AMEX_SCHEME = "AMEX";
-
-// Every string the two data sources emit for Amex, normalized to letters-only + uppercase:
-// SDK `Skyflow.CardType.AMEX` -> "AMEX"; Skyflow vault `card_scheme` -> "AMERICAN EXPRESS".
-const AMEX_SCHEME_ALIASES = new Set(["AMEX", "AMERICANEXPRESS"]);
-
-// Amex issuer identification numbers (IIN/BIN) start with 34 or 37.
-const AMEX_IIN_RE = /^3[47]/;
+export { getCardSchemeFromNumber } from "./cvv-validation";
 
 export type SkyflowCvvValidationType = {
   /** Anchored regex passed to Skyflow's REGEX_MATCH_RULE. */
@@ -31,22 +25,6 @@ export type SkyflowCvvValidationType = {
   /** Placeholder reflecting the expected digit count for the detected brand. */
   placeholder: string;
 };
-
-function isAmexScheme(cardScheme?: string | null): boolean {
-  const normalized = (cardScheme ?? "").toUpperCase().replace(/[^A-Z]/g, "");
-  return AMEX_SCHEME_ALIASES.has(normalized);
-}
-
-/**
- * Detects the card scheme from a (possibly partially masked) card number by its IIN prefix.
- * Only Amex needs distinguishing (4-digit CVV), so this returns {@link AMEX_SCHEME} for an Amex
- * prefix (34/37) and `undefined` otherwise. Non-digit characters (spaces, mask characters) are
- * stripped first, so the SDK's masked `value` (leading digits intact) still resolves correctly.
- */
-export function getCardSchemeFromNumber(cardNumber?: string | null): string | undefined {
-  const digits = (cardNumber ?? "").replace(/\D/g, "");
-  return AMEX_IIN_RE.test(digits) ? AMEX_SCHEME : undefined;
-}
 
 /**
  * Derives the CVV regex + placeholder for a detected card scheme.
@@ -57,7 +35,7 @@ export function getCardSchemeFromNumber(cardNumber?: string | null): string | un
  *   or undefined before a brand is detected.
  */
 export function getCvvValidation(cardScheme?: string | null): SkyflowCvvValidationType {
-  const length = isAmexScheme(cardScheme) ? AMEX_CVV_LENGTH : DEFAULT_CVV_LENGTH;
+  const length = getCvvLength(cardScheme);
 
   return {
     regex: `^[0-9]{${length}}$`,


### PR DESCRIPTION
## Summary

The shared bank-card form (`client-app/shared/payment/components/bank-card-form.vue`, used by the Authorize.Net cart-embedded flow) validated the CVV brand-agnostically (`min(3).max(4)`, fixed mask `"####"`, static `minlength=3`/`maxlength=4`/`placeholder="111"`, no brand detection). A **3-digit CVV on American Express** (needs 4) passed client validation and enabled **Place order**; the mirror — a **4-digit CVV on Visa/Mastercard** (needs 3) — also passed. The malformed CVV was only caught later by Accept.js, after the VCST-5162 flow had already pre-created an unpaid ghost order. Fixes **VCST-5344**.

## Rework note (addresses the review on the previous revision)

The earlier revision duplicated the `AMEX_CVV_LENGTH` / `DEFAULT_CVV_LENGTH` constants and the Amex length rule that PR #2349 (VCST-5202, Skyflow — since merged) added in `shared/payment/utils/`. Per @goldenmaya's review, the constants + length decision are now **shared**, and the brand detectors stay separate.

## Fix

- **New generic core** `client-app/shared/payment/utils/cvv-validation.ts` — single source of truth for the per-brand CVV length: the `AMEX_CVV_LENGTH`/`DEFAULT_CVV_LENGTH` constants, `isAmexScheme`, `getCardSchemeFromNumber` (IIN 34/37 detection), and `getCvvLength(scheme)`.
- `skyflow-cvv-validation.ts` now builds its Skyflow-specific `getCvvValidation` (regex + placeholder) on top of the core and re-exports `getCardSchemeFromNumber`. The merged Skyflow component **and its test file are unchanged** and keep passing via the re-export.
- `bank-card-form.vue` imports `getCardSchemeFromNumber` + `getCvvLength` from the core: brand-conditional yup `.length()`, and the CVV mask / `minlength` / `maxlength` / `placeholder` are reactive computeds derived from the detected brand. No duplicated constants or rule.

No public prop/event/slot or GraphQL contract changed; the diff is confined to the shared payment utils + the one component.

## Test (red → green)

- New `cvv-validation.test.ts` (9 cases) — the shared length decision + brand detection.
- 5 new cases in `bank-card-form.test.ts` — Amex 4-digit accept / 3-digit reject, Visa 3-digit accept / 2-digit reject / mask clamps a 4th digit. Fail on old code, pass with this fix.
- Full affected suites: **33/33 green** (core 9 · Skyflow 12 unchanged · bank-card-form 12).

## Verification

- [x] vue-tsc --build (typecheck) — clean
- [x] eslint (changed files) — **no new findings**; the 2 `sonarjs/null-dereference` errors are pre-existing on untouched lines (identical on `dev`), so husky lint-staged needs `--no-verify` on commit. SonarCloud scores new-code only.
- [x] vitest — 33/33 green
- [x] vite build — clean

## ⚠ Needs visual / E2E verification on deploy

Logic is unit-proven. The per-brand mask/placeholder rendering and the live "Place order stays disabled until a valid brand-correct CVV is entered" gating must be re-confirmed on a real deploy via `/qa-regression frontend` + `/qa-verify-fix VCST-5344`.

JIRA: https://virtocommerce.atlassian.net/browse/VCST-5344

> 🤖 Opened by the QA auto-fix pipeline. **DO NOT MERGE until human review.**

Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.54.0-pr-2352-8cab-8cab3f88.zip