### PR TITLE
fix: resolve SonarQube maintainability code smells

### DIFF
--- a/client-app/core/composables/useAnalytics/useAnalytics.test.ts
+++ b/client-app/core/composables/useAnalytics/useAnalytics.test.ts
@@ -283,7 +283,7 @@ describe("useAnalytics", () => {
     expect(Logger.warn).not.toHaveBeenCalled();
   });
 
-  it("should not dispatch events and not log warnings when no trackers are added", () => {
+  it("should not dispatch events and not log warnings when no trackers are added after development mode reset", () => {
     const event: AnalyticsEventNameType = "viewItem";
     const args: AnalyticsEventMapType["viewItem"] = [mockedProduct, arbitraryParam];
 

--- a/client-app/shared/catalog/composables/useCategory.ts
+++ b/client-app/shared/catalog/composables/useCategory.ts
@@ -4,9 +4,11 @@ import { globals } from "@/core/globals";
 import { Logger } from "@/core/utilities";
 import type { ExtendedQueryCategoryArgsType } from "@/core/api/graphql";
 import type { Category } from "@/core/api/graphql/types";
-import type { MaybeRefOrGetter } from "vue";
+import type { Ref } from "vue";
 
-export function useCategory(options: { currencyCodeOverride?: MaybeRefOrGetter<string | undefined> } = {}) {
+export function useCategory(
+  options: { currencyCodeOverride?: string | Ref<string | undefined> | (() => string | undefined) } = {},
+) {
   const loading = ref(false);
   const category = shallowRef<Category>();
 

--- a/client-app/shared/catalog/composables/useProduct.ts
+++ b/client-app/shared/catalog/composables/useProduct.ts
@@ -4,9 +4,11 @@ import { getProduct } from "@/core/api/graphql/catalog";
 import { NAVIGATION_OUTLINE } from "@/core/constants";
 import { Logger } from "@/core/utilities";
 import type { Product } from "@/core/api/graphql/types";
-import type { MaybeRefOrGetter, Ref } from "vue";
+import type { Ref } from "vue";
 
-export function useProduct(options: { currencyCodeOverride?: MaybeRefOrGetter<string | undefined> } = {}) {
+export function useProduct(
+  options: { currencyCodeOverride?: string | Ref<string | undefined> | (() => string | undefined) } = {},
+) {
   const fetching: Ref<boolean> = ref(true);
   const product: Ref<Product | undefined> = ref();
   const navigationOutline = useLocalStorage<string>(NAVIGATION_OUTLINE, "");

--- a/client-app/shared/catalog/composables/useProductVariations.ts
+++ b/client-app/shared/catalog/composables/useProductVariations.ts
@@ -14,7 +14,7 @@ export interface IUseProductVariationsOptions {
   /** Products filters from useProducts composable */
   productsFilters: Ref<ProductsFiltersType>;
   /** Sort expression string */
-  sort?: MaybeRef<string | undefined>;
+  sort?: string | Ref<string | undefined> | (() => string | undefined);
   /** Filter expression for variations */
   variationsFilterExpression: MaybeRef<string>;
   /** Custom filter builder function - if provided, uses this instead of productsFilters */


### PR DESCRIPTION
## Description

<img width="1891" height="960" alt="image" src="https://github.com/user-attachments/assets/b05ba9d1-315e-4652-8a30-ffc092c06549" />


Resolves the 4 open SonarQube **Maintainability** code smells.

| File | Issue | Fix |
|------|-------|-----|
| `useCategory.ts` | S4782: optional `?` + `undefined` in type is redundant | `MaybeRefOrGetter<string \| undefined>` → `string \| Ref<string \| undefined> \| (() => string \| undefined)` |
| `useProduct.ts` | same | same |
| `useProductVariations.ts` | same on optional `sort` | `MaybeRef<string \| undefined>` → `string \| Ref<string \| undefined> \| (() => string \| undefined)` |
| `useAnalytics.test.ts` | duplicate test title within the suite | renamed to be unique |

### Why this shape (and not just `MaybeRefOrGetter<string>`)

SonarQube's type-aware analyzer expands `MaybeRefOrGetter<string | undefined>` to `string | undefined | Ref<…> | (() => …)`, exposing a **top-level bare `undefined`** that is redundant with the `?`. The fix removes that redundant top-level `undefined` while keeping `undefined` **nested** inside the `Ref<…>` / getter forms — because real callers genuinely pass values resolving to `string | undefined`:

- `product.vue` → `useLoyaltyCatalogCurrency()` returns `ComputedRef<string | undefined>`
- `product.vue` → `variationsSort` is `ComputedRef<string | undefined>`
- `category.vue` → passes a `() => string | undefined` getter

Simply dropping `undefined` (`MaybeRefOrGetter<string>`) compiles under a no-op `vue-tsc --noEmit` but **fails the real `vue-tsc --build`** with TS2322 on those callers. This shape matches the existing pattern in `useProducts.ts`.

## Verification

- `vue-tsc --build --force` (the command `yarn build` runs) → 0 errors
- `sonarjs/no-redundant-optional` (S4782) run with type info on all three files → no findings
- `vitest` on `useAnalytics.test.ts` → 11/11 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.52.0-pr-2355-dad2-dad2dd11.zip