### PR TITLE
fix(VCST-5413): keep slider handle styling when nouislider CSS lazy-loads

### DIFF
--- a/client-app/ui-kit/components/molecules/slider/nouislider.layer.css
+++ b/client-app/ui-kit/components/molecules/slider/nouislider.layer.css
@@ -1,0 +1,6 @@
+/*
+ * nouislider defaults in a low-priority `nouislider` layer. The slider CSS is lazy-loaded
+ * (vc-slider.vue) so it injects after the app CSS; layering it lets our unlayered
+ * `.noUi-*` overrides win regardless of load order, while structural rules still apply.
+ */
+@import "nouislider/dist/nouislider.css" layer(nouislider);

--- a/client-app/ui-kit/components/molecules/slider/vc-slider.vue
+++ b/client-app/ui-kit/components/molecules/slider/vc-slider.vue
@@ -392,9 +392,9 @@ onMounted(async () => {
     return;
   }
 
-  // nouislider (~94 KB) and its CSS load with the slider (price filter) rather than shipping
-  // in the eager bundle on every page.
-  const [{ create }] = await Promise.all([import("nouislider"), import("nouislider/dist/nouislider.css")]);
+  // Lazy-loaded to keep nouislider (~94 KB) off the eager bundle. CSS goes through a
+  // `nouislider` cascade layer (nouislider.layer.css) so this late chunk can't override our styles.
+  const [{ create }] = await Promise.all([import("nouislider"), import("./nouislider.layer.css")]);
 
   if (!sliderRef.value) {
     return;


### PR DESCRIPTION
## Description

Price filter slider looked wrong: handles were fat 34×28 ovals, track too thick. Only on the storefront, not in Storybook.

**Cause**

- #2345 made nouislider's CSS load lazily — good for bundle size.
- Side effect: it now loads *last*, after our app CSS.
- Our styles and nouislider's defaults are equally specific, so the cascade falls back to load order — last one wins. That's now nouislider, so its chunky defaults override our design.

**Fix**

- Keep nouislider lazy (don't lose the perf win).
- Load its CSS into a dedicated cascade layer.
- Layered styles always lose to our normal styles, no matter what loads last → our design wins again.

One tiny wrapper file + one changed import. No logic changes.

**Verified**

- Handles back to 18×18 circles, track thin again.
- Confirmed even though nouislider's CSS still loads last.
- Ticket's regression check passes.

## References
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5413
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.53.0-pr-2366-83ba-83ba32ab.zip
