### PR TITLE
fix(VCST-5407): fix security findings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     groups:
       actions:
         patterns:
@@ -16,6 +18,8 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
     groups:
       # Batch routine, low-risk version bumps into a single PR to reduce noise.
       dependencies:

--- a/.github/workflows/deploy-cloud.yml
+++ b/.github/workflows/deploy-cloud.yml
@@ -35,6 +35,22 @@ on:
         default: 'https://portal.virtocommerce.cloud'
         required: false
         type: string
+    secrets:
+      REPO_TOKEN:
+        description: 'GitHub token used to create the deploy PR/commit and update deployment status'
+        required: true
+      VIRTOCLOUD_KEY_VCPT_VCST:
+        description: 'Virto Cloud token used to check deployment status'
+        required: false
+      CLOUD_INSTANCE_BASE_URL:
+        description: 'Jira cloud instance base URL (for pushing deployment info)'
+        required: false
+      CLIENT_ID:
+        description: 'Jira client id (for pushing deployment info)'
+        required: false
+      CLIENT_SECRET:
+        description: 'Jira client secret (for pushing deployment info)'
+        required: false
   workflow_dispatch:
     inputs:
       cmPath:

--- a/.github/workflows/storybook-ci.yml
+++ b/.github/workflows/storybook-ci.yml
@@ -192,4 +192,9 @@ jobs:
       environmentId: ${{ github.ref == 'refs/heads/master' && 'qa' || 'dev' }}
       jiraKeys: ${{ needs.ci.outputs.jira-keys }}
       forceCommit: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev' }}
-    secrets: inherit
+    secrets:
+      REPO_TOKEN: ${{ secrets.REPO_TOKEN }}
+      VIRTOCLOUD_KEY_VCPT_VCST: ${{ secrets.VIRTOCLOUD_KEY_VCPT_VCST }}
+      CLOUD_INSTANCE_BASE_URL: ${{ secrets.CLOUD_INSTANCE_BASE_URL }}
+      CLIENT_ID: ${{ secrets.CLIENT_ID }}
+      CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}

--- a/.github/workflows/theme-ci.yml
+++ b/.github/workflows/theme-ci.yml
@@ -279,4 +279,9 @@ jobs:
       environmentId: ${{ ((github.event_name == 'pull_request' && github.base_ref == 'dev') || github.ref == 'refs/heads/master') && 'qa' || 'dev' }}
       jiraKeys: ${{ needs.ci.outputs.jira-keys }}
       forceCommit: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev' }}
-    secrets: inherit
+    secrets:
+      REPO_TOKEN: ${{ secrets.REPO_TOKEN }}
+      VIRTOCLOUD_KEY_VCPT_VCST: ${{ secrets.VIRTOCLOUD_KEY_VCPT_VCST }}
+      CLOUD_INSTANCE_BASE_URL: ${{ secrets.CLOUD_INSTANCE_BASE_URL }}
+      CLIENT_ID: ${{ secrets.CLIENT_ID }}
+      CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}


### PR DESCRIPTION
## Description
## Fix Semgrep code-scanning findings in GitHub Actions workflows

Resolves the two high-severity `secrets: inherit` errors and the Dependabot cooldown warnings flagged by Semgrep code scanning.

### Changes
- **`secrets: inherit` → explicit secret maps** (alerts #179, #171). The `deploy-cloud` reusable workflow was receiving *every* repo secret via `inherit` (CWE-250, least-privilege violation). Now `deploy-cloud.yml` declares the five secrets it actually uses under `workflow_call.secrets`, and both callers (`theme-ci.yml`, `storybook-ci.yml`) pass only those explicitly.
- **Dependabot cooldown** (alerts #160, #161). Added `cooldown: { default-days: 7 }` to the `github-actions` and `npm` ecosystems so newly published versions wait 7 days before a bump PR is opened — a supply-chain guard.

### Notes
- No behavior change: the same secrets reach the deploy job; only unrelated secrets are no longer exposed.
- Mutable-tag warnings (first-party `VirtoCommerce/*@master` refs) intentionally left as-is.
## References
### Jira-link:
<!-- Put link to your task in Jira here -->https://virtocommerce.atlassian.net/browse/VCST-5407
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.53.0-pr-2367-b869-b869a9ff.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI configuration only: same deploy secrets are passed explicitly with no application logic changes; low blast radius if mappings stay correct.
> 
> **Overview**
> Addresses Semgrep code-scanning findings by tightening CI secret exposure and Dependabot supply-chain timing.
> 
> **`deploy-cloud` reusable workflow** now declares five `workflow_call` secrets (`REPO_TOKEN` required; Virto Cloud and Jira-related secrets optional). **`theme-ci`** and **`storybook-ci`** no longer use `secrets: inherit` when calling it—they pass only those mapped secrets. Deploy behavior should be unchanged; unrelated repository secrets are no longer forwarded into the reusable workflow.
> 
> **Dependabot** adds `cooldown.default-days: 7` for both **github-actions** and **npm** updates so bump PRs wait a week after a version is published.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b869a9ff895ad520619121719bcbfc547dc5961a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->