### PR TITLE
[POC] VCST-5219: shared applyLocale seam for boot + builder preview

### DIFF
--- a/client-app/app-runner.ts
+++ b/client-app/app-runner.ts
@@ -44,7 +44,6 @@ import { templateBlocks } from "@/shared/static-content";
 import { uiKit } from "@/ui-kit";
 import { getLocales as getUIKitLocales } from "@/ui-kit/utilities/getLocales";
 import App from "./App.vue";
-import type { ILanguage } from "./core/types";
 import type { PageContextResponseType } from "./core/api/graphql/types";
 import type { PageBuilderPluginOptionsType } from "./plugins/builder-preview/models/PageBuilderPluginOptionsType";
 
@@ -83,13 +82,14 @@ export default async () => {
     currentLanguage,
     currentMaybeShortLocale,
     defaultStoreCulture,
-    initLocale,
+    applyLocale,
+    registerLocaleLoader,
     fetchLocaleMessages,
     mergeLocalesMessages,
     resolveLocale,
+    normalizeToSupportedCulture,
     getUrlWithoutPossibleLocale,
     resolvePossibleLocale,
-    supportedLanguages,
   } = useLanguages();
   const { currentCurrency } = useCurrency();
   const { init: initializeHotjar } = useHotjar();
@@ -160,17 +160,26 @@ export default async () => {
    */
   const head = createHead();
 
-  const currentCultureName =
-    previewCultureName &&
-    supportedLanguages.value.some((language: ILanguage) => language.cultureName === previewCultureName)
-      ? previewCultureName
-      : resolveLocale();
+  // `previewCultureName` is only set in preview mode; tolerate short/differently-cased values
+  // ("fr", "fr-fr") instead of silently falling back to the store default (VCST-5219).
+  const currentCultureName = normalizeToSupportedCulture(previewCultureName) ?? resolveLocale();
   const isDefaultLocaleInUse = defaultStoreCulture.value === currentCultureName;
 
   const i18n = createI18n(currentCultureName, currentCurrency.value.code, fallback);
+
+  // The UI kit loads its locale bundles through the shared locale-loader seam, so boot and any
+  // runtime locale switch (e.g. builder preview, VCST-5219) share one copy of this logic.
+  registerLocaleLoader(async (i18nInstance, language) => {
+    const uiKitMessages = await getUIKitLocales(FALLBACK_LOCALE, language.twoLetterLanguageName);
+    mergeLocalesMessages(i18nInstance, language.twoLetterLanguageName, uiKitMessages.messages);
+    if (language.twoLetterLanguageName !== FALLBACK_LOCALE) {
+      mergeLocalesMessages(i18nInstance, FALLBACK_LOCALE, uiKitMessages.fallbackMessages);
+    }
+  });
+
   // Keep the URL as `/designer-preview` in preview mode (no `/{lang}` prefix) so the fixed preview
   // route keeps resolving; the locale still switches for content and chrome (VCST-5219).
-  await initLocale(i18n, currentCultureName, { rewriteUrl: !isPreview });
+  await applyLocale(i18n, currentCultureName, { rewriteUrl: !isPreview });
 
   const router = createRouter({
     base: isPreview || isDefaultLocaleInUse ? "" : currentMaybeShortLocale.value,
@@ -245,11 +254,6 @@ export default async () => {
   app.use(contextPlugin, themeContext.value);
   app.use(configPlugin, themeContext.value);
 
-  const UIKitMessages = await getUIKitLocales(FALLBACK_LOCALE, currentLanguage.value?.twoLetterLanguageName);
-  mergeLocalesMessages(i18n, currentLanguage.value?.twoLetterLanguageName, UIKitMessages.messages);
-  if (currentLanguage.value?.twoLetterLanguageName !== FALLBACK_LOCALE) {
-    mergeLocalesMessages(i18n, FALLBACK_LOCALE, UIKitMessages.fallbackMessages);
-  }
   app.use(uiKit);
 
   app.use(applicationInsightsPlugin, { router });

--- a/client-app/app-runner.ts
+++ b/client-app/app-runner.ts
@@ -15,6 +15,7 @@ import { useHotjar } from "@/core/composables/useHotjar";
 import { useLanguages } from "@/core/composables/useLanguages";
 import { DEFAULT_NOTIFICATION_DURATION, FALLBACK_LOCALE, IS_DEVELOPMENT } from "@/core/constants";
 import { setGlobals } from "@/core/globals";
+import { registerLocaleLoader } from "@/core/locale-loaders";
 import {
   applicationInsightsPlugin,
   authPlugin,
@@ -83,7 +84,6 @@ export default async () => {
     currentMaybeShortLocale,
     defaultStoreCulture,
     applyLocale,
-    registerLocaleLoader,
     fetchLocaleMessages,
     mergeLocalesMessages,
     resolveLocale,
@@ -169,7 +169,7 @@ export default async () => {
 
   // The UI kit loads its locale bundles through the shared locale-loader seam, so boot and any
   // runtime locale switch (e.g. builder preview, VCST-5219) share one copy of this logic.
-  registerLocaleLoader(async (i18nInstance, language) => {
+  registerLocaleLoader("ui-kit", async (i18nInstance, language) => {
     const uiKitMessages = await getUIKitLocales(FALLBACK_LOCALE, language.twoLetterLanguageName);
     mergeLocalesMessages(i18nInstance, language.twoLetterLanguageName, uiKitMessages.messages);
     if (language.twoLetterLanguageName !== FALLBACK_LOCALE) {

--- a/client-app/app-runner.ts
+++ b/client-app/app-runner.ts
@@ -36,7 +36,7 @@ import { init as initPushNotifications } from "@/modules/push-messages";
 import { init as initModuleQuotes } from "@/modules/quotes";
 import { BUILDER_IO_TRACE_MARKER, consoleIgnoredErrors } from "@/pages/matcher/builderIo/console-ignored-errors";
 import { isPreviewMode as isBuilderIoPreviewMode } from "@/plugins/builder-io-preview/utils";
-import { getPreviewCultureName, isPreviewMode as isPageBuilderPreviewMode } from "@/plugins/builder-preview/utils";
+import { getPreviewBootOptions as getPageBuilderPreviewBoot } from "@/plugins/builder-preview/utils";
 import { createRouter } from "@/router";
 import { useUser } from "@/shared/account";
 import ProductBlocks from "@/shared/catalog/components/product";
@@ -109,12 +109,8 @@ export default async () => {
 
   // get initialization query parameters
   const pathname = globalThis.location.pathname;
-  // In Page Builder preview/designer the URL carries the edited page's language as `?cultureName=`
-  // and the route is a fixed `/designer-preview` (no `/{lang}` prefix). Honor that culture so the
-  // preview renders in the page's language instead of the store default (VCST-5219).
-  const isPageBuilderPreview = isPageBuilderPreviewMode();
-  const previewCultureName = isPageBuilderPreview ? getPreviewCultureName() : undefined;
-  const possibleCultureName = previewCultureName ?? resolvePossibleLocale(pathname);
+  const pageBuilderPreview = getPageBuilderPreviewBoot();
+  const possibleCultureName = pageBuilderPreview.cultureName ?? resolvePossibleLocale(pathname);
   const permalink = getPermalink(pathname, getUrlWithoutPossibleLocale);
 
   const domain = IS_DEVELOPMENT
@@ -160,9 +156,9 @@ export default async () => {
    */
   const head = createHead();
 
-  // `previewCultureName` is only set in preview mode; tolerate short/differently-cased values
+  // A preview boot carries the edited page's language; tolerate short/differently-cased values
   // ("fr", "fr-fr") instead of silently falling back to the store default (VCST-5219).
-  const currentCultureName = normalizeToSupportedCulture(previewCultureName) ?? resolveLocale();
+  const currentCultureName = normalizeToSupportedCulture(pageBuilderPreview.cultureName) ?? resolveLocale();
   const isDefaultLocaleInUse = defaultStoreCulture.value === currentCultureName;
 
   const i18n = createI18n(currentCultureName, currentCurrency.value.code, fallback);
@@ -177,12 +173,10 @@ export default async () => {
     }
   });
 
-  // Keep the URL as `/designer-preview` in preview mode (no `/{lang}` prefix) so the fixed preview
-  // route keeps resolving; the locale still switches for content and chrome (VCST-5219).
-  await applyLocale(i18n, currentCultureName, { rewriteUrl: !isPageBuilderPreview });
+  await applyLocale(i18n, currentCultureName, { rewriteUrl: pageBuilderPreview.useLocalePrefix });
 
   const router = createRouter({
-    base: isPageBuilderPreview || isDefaultLocaleInUse ? "" : currentMaybeShortLocale.value,
+    base: pageBuilderPreview.useLocalePrefix && !isDefaultLocaleInUse ? currentMaybeShortLocale.value : "",
   });
 
   /**
@@ -201,13 +195,13 @@ export default async () => {
   });
 
   // Seed Apollo cache with initial slugInfo from pageContext to avoid the first network call.
-  // pageContext was fetched with `possibleCultureName`; if in preview mode an unsupported/mistyped
-  // `cultureName` query was sent to getPageContext but then rejected in favor of the resolved
-  // culture, the returned slugInfo belongs to a different culture — skip seeding so it isn't cached
-  // under the wrong culture key (VCST-5219).
-  const previewCultureRejected =
-    isPageBuilderPreview && !!previewCultureName && previewCultureName !== currentCultureName;
-  if (!previewCultureRejected) {
+  // pageContext was fetched with the raw preview `cultureName`. When the app resolved to a different
+  // culture — an unsupported value, or a short form like "fr" normalized to "fr-FR" — the returned
+  // slugInfo belongs to another culture, so skip seeding rather than cache it under the wrong key
+  // (VCST-5219).
+  const previewCultureDiffersFromResolved =
+    !!pageBuilderPreview.cultureName && pageBuilderPreview.cultureName !== currentCultureName;
+  if (!previewCultureDiffersFromResolved) {
     try {
       const baseVariables = {
         userId: user.value.id,
@@ -259,7 +253,7 @@ export default async () => {
 
   app.use(applicationInsightsPlugin, { router });
 
-  if (isPageBuilderPreviewMode()) {
+  if (pageBuilderPreview.isActive) {
     const builderPreviewPlugin = (await import("@/plugins/builder-preview/builder-preview.plugin").catch(Logger.error))
       ?.default;
     if (builderPreviewPlugin) {

--- a/client-app/core/composables/useLanguages.test.ts
+++ b/client-app/core/composables/useLanguages.test.ts
@@ -80,6 +80,7 @@ vi.mock("./useThemeContext", () => ({
 vi.mock("@vueuse/core", () => ({
   useLocalStorage: () => hoisted.state.pinnedLocale,
   useSessionStorage: () => hoisted.state.previousCultureSlug,
+  noop: () => {},
 }));
 
 vi.mock("yup", () => ({

--- a/client-app/core/composables/useLanguages.ts
+++ b/client-app/core/composables/useLanguages.ts
@@ -3,7 +3,7 @@ import { merge } from "lodash-es";
 import { computed, ref } from "vue";
 import { setLocale as setLocaleForYup } from "yup";
 import { LOCALE_ID_REGEX } from "@/core/constants/locale";
-import { Logger } from "@/core/utilities";
+import { runLocaleLoaders } from "@/core/locale-loaders";
 import { getDefaultNumberFormats } from "@/i18n";
 import { useUser } from "@/shared/account/composables/useUser";
 import { getCatalogBasePath } from "@/shared/catalog/composables/useCatalogBasePath";
@@ -13,14 +13,6 @@ import type { ILanguage } from "../types";
 import type { I18n } from "@/i18n";
 import type { LocaleMessage } from "@intlify/core-base";
 import type { Composer, LocaleMessageValue } from "vue-i18n";
-
-/**
- * Loads and merges extra locale messages (UI kit, module bundles, …) for the given language.
- * Registered via `registerLocaleLoader` and re-run by `applyLocale` on every locale switch,
- * so runtime switches (e.g. the builder preview applying the edited page's culture, VCST-5219)
- * stay in sync with what boot loaded.
- */
-export type LocaleLoaderType = (i18n: I18n, language: ILanguage) => Promise<void>;
 
 const { themeContext } = useThemeContext();
 
@@ -55,18 +47,6 @@ const currentMaybeShortLocale = computed(() => {
   return tryShortLocale(currentLanguage.value?.cultureName ?? "");
 });
 
-const localeLoaders: LocaleLoaderType[] = [];
-
-/**
- * Registers a loader of extra locale messages (UI kit bundles, module bundles, …).
- * Every registered loader is (re-)run by `applyLocale`, so a single registration keeps the
- * messages in sync across all runtime locale switches. Registering the same loader twice is a no-op.
- */
-function registerLocaleLoader(loader: LocaleLoaderType): void {
-  if (!localeLoaders.includes(loader)) {
-    localeLoaders.push(loader);
-  }
-}
 
 function tryShortLocale(localeOrCultureName: string) {
   const twoLetterLanguageName = localeOrCultureName.slice(0, 2);
@@ -171,14 +151,7 @@ async function applyLocale(i18n: I18n, cultureName: string, options?: { rewriteU
     getDefaultNumberFormats(currentCurrency.value.code),
   );
 
-  const language = currentLanguage.value ?? defaultStoreLanguage.value;
-  await Promise.all(
-    localeLoaders.map((load) =>
-      load(i18n, language).catch((error: unknown) =>
-        Logger.error(`Failed to load extra locale messages for "${cultureName}"`, error),
-      ),
-    ),
-  );
+  await runLocaleLoaders(i18n, currentLanguage.value ?? defaultStoreLanguage.value);
 }
 
 /**
@@ -340,7 +313,6 @@ export function useLanguages() {
 
     initLocale,
     applyLocale,
-    registerLocaleLoader,
     resolveLocale,
     normalizeToSupportedCulture,
     fetchLocaleMessages,

--- a/client-app/core/composables/useLanguages.ts
+++ b/client-app/core/composables/useLanguages.ts
@@ -2,13 +2,25 @@ import { useLocalStorage, useSessionStorage } from "@vueuse/core";
 import { merge } from "lodash-es";
 import { computed, ref } from "vue";
 import { setLocale as setLocaleForYup } from "yup";
+import { LOCALE_ID_REGEX } from "@/core/constants/locale";
+import { Logger } from "@/core/utilities";
+import { getDefaultNumberFormats } from "@/i18n";
 import { useUser } from "@/shared/account/composables/useUser";
 import { getCatalogBasePath } from "@/shared/catalog/composables/useCatalogBasePath";
+import { useCurrency } from "./useCurrency";
 import { useThemeContext } from "./useThemeContext";
 import type { ILanguage } from "../types";
 import type { I18n } from "@/i18n";
 import type { LocaleMessage } from "@intlify/core-base";
 import type { Composer, LocaleMessageValue } from "vue-i18n";
+
+/**
+ * Loads and merges extra locale messages (UI kit, module bundles, …) for the given language.
+ * Registered via `registerLocaleLoader` and re-run by `applyLocale` on every locale switch,
+ * so runtime switches (e.g. the builder preview applying the edited page's culture, VCST-5219)
+ * stay in sync with what boot loaded.
+ */
+export type LocaleLoaderType = (i18n: I18n, language: ILanguage) => Promise<void>;
 
 const { themeContext } = useThemeContext();
 
@@ -43,6 +55,19 @@ const currentMaybeShortLocale = computed(() => {
   return tryShortLocale(currentLanguage.value?.cultureName ?? "");
 });
 
+const localeLoaders: LocaleLoaderType[] = [];
+
+/**
+ * Registers a loader of extra locale messages (UI kit bundles, module bundles, …).
+ * Every registered loader is (re-)run by `applyLocale`, so a single registration keeps the
+ * messages in sync across all runtime locale switches. Registering the same loader twice is a no-op.
+ */
+function registerLocaleLoader(loader: LocaleLoaderType): void {
+  if (!localeLoaders.includes(loader)) {
+    localeLoaders.push(loader);
+  }
+}
+
 function tryShortLocale(localeOrCultureName: string) {
   const twoLetterLanguageName = localeOrCultureName.slice(0, 2);
 
@@ -60,7 +85,7 @@ function fetchLocaleMessages(locale: string): Promise<LocaleMessage> {
   // The locale may originate from user-controlled input (e.g. a `?cultureName=` query param).
   // Reject anything that isn't a plain locale identifier before using it to index the bundle map,
   // so it can't select an unexpected target or traverse paths (CodeQL: unvalidated dynamic method call).
-  if (!/^[a-zA-Z0-9-]+$/.test(locale)) {
+  if (!LOCALE_ID_REGEX.test(locale)) {
     return import("../../../locales/en.json"); // can't use variables in import
   }
 
@@ -126,6 +151,51 @@ async function initLocale(i18n: I18n, cultureName: string, options?: { rewriteUr
   }
 
   document.documentElement.setAttribute("lang", cultureName);
+}
+
+/**
+ * Fully applies a locale at runtime: base app messages (`initLocale`), per-culture number formats,
+ * and every registered locale loader (UI kit, module bundles, …). This is the single shared
+ * "switch the app language" entry point used by both storefront boot and the builder preview,
+ * so the two can't silently diverge (VCST-5219).
+ *
+ * Loader failures are isolated and logged: a missing optional bundle must degrade to fallback
+ * messages, never break the locale switch itself.
+ */
+async function applyLocale(i18n: I18n, cultureName: string, options?: { rewriteUrl?: boolean }): Promise<void> {
+  await initLocale(i18n, cultureName, options);
+
+  const { currentCurrency } = useCurrency();
+  (i18n.global as unknown as Composer).mergeNumberFormat(
+    cultureName,
+    getDefaultNumberFormats(currentCurrency.value.code),
+  );
+
+  const language = currentLanguage.value ?? defaultStoreLanguage.value;
+  await Promise.all(
+    localeLoaders.map((load) =>
+      load(i18n, language).catch((error: unknown) =>
+        Logger.error(`Failed to load extra locale messages for "${cultureName}"`, error),
+      ),
+    ),
+  );
+}
+
+/**
+ * Maps a raw, possibly user-supplied locale value ("fr", "fr-fr", "fr-FR") to the exact
+ * `cultureName` of a supported store language, or `undefined` if no language matches.
+ */
+function normalizeToSupportedCulture(localeOrCultureName?: string): string | undefined {
+  const value = localeOrCultureName?.toLowerCase();
+
+  if (!value) {
+    return undefined;
+  }
+
+  return supportedLanguages.value.find(
+    (language) =>
+      language.cultureName.toLowerCase() === value || language.twoLetterLanguageName.toLowerCase() === value,
+  )?.cultureName;
 }
 
 function getLocaleFromUrl(): string | undefined {
@@ -269,7 +339,10 @@ export function useLanguages() {
     }),
 
     initLocale,
+    applyLocale,
+    registerLocaleLoader,
     resolveLocale,
+    normalizeToSupportedCulture,
     fetchLocaleMessages,
     mergeLocalesMessages,
 

--- a/client-app/core/constants/locale.ts
+++ b/client-app/core/constants/locale.ts
@@ -79,3 +79,11 @@ export const languageToCountryMap: Record<string, string> = {
 };
 
 export const FALLBACK_LOCALE = "en";
+
+/**
+ * Plain locale/culture identifier (e.g. "en", "en-US").
+ * The value may originate from user-controlled input (e.g. a `?cultureName=` query param) and is
+ * used as a dynamic object key / bundle-map index, so anything else must be rejected
+ * (CodeQL: remote property injection, unvalidated dynamic method call).
+ */
+export const LOCALE_ID_REGEX = /^[a-zA-Z0-9-]+$/;

--- a/client-app/core/locale-loaders.ts
+++ b/client-app/core/locale-loaders.ts
@@ -1,0 +1,44 @@
+import { Logger } from "@/core/utilities";
+import type { ILanguage } from "@/core/types";
+import type { I18n } from "@/i18n";
+
+/**
+ * Loads and merges extra locale messages (UI kit, module bundles, …) for the given language.
+ * Registered via `registerLocaleLoader` and re-run by `applyLocale` (see useLanguages) on every
+ * locale switch, so runtime switches (e.g. the builder preview applying the edited page's culture,
+ * VCST-5219) stay in sync with what boot loaded.
+ *
+ * Loaders run concurrently and must merge messages under namespaces they own (e.g. `ui_kit.*`,
+ * a module's own keys); overlapping keys across loaders would resolve last-writer-wins.
+ */
+export type LocaleLoaderType = (i18n: I18n, language: ILanguage) => Promise<void>;
+
+const localeLoaders = new Map<string, LocaleLoaderType>();
+
+/**
+ * Registers a locale loader under a stable key ("ui-kit", "module:quotes", …).
+ * Re-registering the same key overwrites the previous loader, so repeated boots
+ * (HMR, tests) don't accumulate duplicates.
+ */
+export function registerLocaleLoader(key: string, loader: LocaleLoaderType): void {
+  localeLoaders.set(key, loader);
+}
+
+/**
+ * Runs every registered loader for the given language. Loader failures are isolated and logged:
+ * a missing optional bundle must degrade to fallback messages, never break the locale switch.
+ */
+export async function runLocaleLoaders(i18n: I18n, language: ILanguage): Promise<void> {
+  await Promise.all(
+    Array.from(localeLoaders.values(), (load) =>
+      load(i18n, language).catch((error: unknown) =>
+        Logger.error(`Failed to load extra locale messages for "${language.cultureName}"`, error),
+      ),
+    ),
+  );
+}
+
+/** Test/HMR hygiene: clears all registered loaders. */
+export function resetLocaleLoaders(): void {
+  localeLoaders.clear();
+}

--- a/client-app/i18n.ts
+++ b/client-app/i18n.ts
@@ -1,11 +1,31 @@
 import { createI18n as _createI18n } from "vue-i18n";
+import { LOCALE_ID_REGEX } from "@/core/constants/locale";
 import type { LocaleMessage } from "@intlify/core-base";
+import type { IntlNumberFormat } from "vue-i18n";
+
+/**
+ * Default per-locale number formats. Registered for the boot locale by `createI18n` and for every
+ * locale switched to at runtime by `applyLocale` (see useLanguages), so prices/numbers always
+ * format in the active culture instead of silently keeping the boot culture (VCST-5219).
+ */
+export function getDefaultNumberFormats(currency: string): IntlNumberFormat {
+  return {
+    decimal: {
+      style: "decimal",
+    },
+    currency: {
+      style: "currency",
+      notation: "standard",
+      currency,
+    },
+  };
+}
 
 export function createI18n(locale: string, currency: string, fallback?: { locale: string; message: LocaleMessage }) {
   // `locale` may originate from user-controlled input (e.g. a `?cultureName=` query param) and is
   // used below as a dynamic object key. Only accept a plain locale identifier, otherwise fall back,
   // so it can't inject an unexpected property name (CodeQL: remote property injection).
-  const safeLocale = /^[a-zA-Z0-9-]+$/.test(locale) ? locale : (fallback?.locale ?? "en");
+  const safeLocale = LOCALE_ID_REGEX.test(locale) ? locale : (fallback?.locale ?? "en");
 
   let fallbackMessage = {};
   if (fallback) {
@@ -55,16 +75,7 @@ export function createI18n(locale: string, currency: string, fallback?: { locale
     fallbackWarn: false,
     missingWarn: false,
     numberFormats: {
-      [safeLocale]: {
-        decimal: {
-          style: "decimal",
-        },
-        currency: {
-          style: "currency",
-          notation: "standard",
-          currency,
-        },
-      },
+      [safeLocale]: getDefaultNumberFormats(currency),
     },
   });
 }

--- a/client-app/modules/utils.ts
+++ b/client-app/modules/utils.ts
@@ -1,23 +1,19 @@
 import { useLanguages } from "@/core/composables/useLanguages";
 import { FALLBACK_LOCALE } from "@/core/constants";
+import { registerLocaleLoader } from "@/core/locale-loaders";
 import { Logger } from "@/core/utilities";
 import type { ILanguage } from "@/core/types";
 import type { I18n } from "@/i18n";
 import type { LocaleMessageValue } from "vue-i18n";
 
-const modulesWithLocaleLoader = new Set<string>();
-
 export async function loadModuleLocale(i18n: I18n, moduleName: string): Promise<void> {
-  const { currentLanguage, registerLocaleLoader } = useLanguages();
+  const { currentLanguage } = useLanguages();
 
   // Re-load this module's messages on every runtime locale switch (e.g. the builder preview
   // applying the edited page's culture, VCST-5219), not just once at module init.
-  if (!modulesWithLocaleLoader.has(moduleName)) {
-    modulesWithLocaleLoader.add(moduleName);
-    registerLocaleLoader((i18nInstance: I18n, language: ILanguage) =>
-      mergeModuleLocales(i18nInstance, moduleName, language),
-    );
-  }
+  registerLocaleLoader(`module:${moduleName}`, (i18nInstance: I18n, language: ILanguage) =>
+    mergeModuleLocales(i18nInstance, moduleName, language),
+  );
 
   await mergeModuleLocales(i18n, moduleName, currentLanguage.value);
 }

--- a/client-app/modules/utils.ts
+++ b/client-app/modules/utils.ts
@@ -1,12 +1,30 @@
 import { useLanguages } from "@/core/composables/useLanguages";
 import { FALLBACK_LOCALE } from "@/core/constants";
 import { Logger } from "@/core/utilities";
+import type { ILanguage } from "@/core/types";
 import type { I18n } from "@/i18n";
 import type { LocaleMessageValue } from "vue-i18n";
 
+const modulesWithLocaleLoader = new Set<string>();
+
 export async function loadModuleLocale(i18n: I18n, moduleName: string): Promise<void> {
-  const { currentLanguage, mergeLocalesMessages } = useLanguages();
-  const locale = currentLanguage.value?.twoLetterLanguageName || FALLBACK_LOCALE;
+  const { currentLanguage, registerLocaleLoader } = useLanguages();
+
+  // Re-load this module's messages on every runtime locale switch (e.g. the builder preview
+  // applying the edited page's culture, VCST-5219), not just once at module init.
+  if (!modulesWithLocaleLoader.has(moduleName)) {
+    modulesWithLocaleLoader.add(moduleName);
+    registerLocaleLoader((i18nInstance: I18n, language: ILanguage) =>
+      mergeModuleLocales(i18nInstance, moduleName, language),
+    );
+  }
+
+  await mergeModuleLocales(i18n, moduleName, currentLanguage.value);
+}
+
+async function mergeModuleLocales(i18n: I18n, moduleName: string, language?: ILanguage): Promise<void> {
+  const { mergeLocalesMessages } = useLanguages();
+  const locale = language?.twoLetterLanguageName || FALLBACK_LOCALE;
 
   try {
     const [moduleFallbackMessages, moduleMessages] = await Promise.all<LocaleMessageValue[]>([

--- a/client-app/plugins/builder-preview/builder-preview.plugin.ts
+++ b/client-app/plugins/builder-preview/builder-preview.plugin.ts
@@ -1,9 +1,7 @@
 import { useGlobalInterceptors } from "@/core/api/common";
 import { useLanguages } from "@/core/composables/useLanguages";
-import { FALLBACK_LOCALE } from "@/core/constants";
 import { globals, setGlobals } from "@/core/globals";
 import { Logger } from "@/core/utilities";
-import { getLocales as getUIKitLocales } from "@/ui-kit/utilities/getLocales";
 import { useStaticPage } from "@/shared/static-content";
 import { templateBlocks } from "@/shared/static-content/components";
 import PreviewPage from "./components/preview-page.vue";
@@ -35,33 +33,36 @@ declare type TransferDataType = {
   cultureName?: string;
 };
 
+// Serializes locale switches: builder messages arrive concurrently and interleaved
+// `applyPreviewLocale` runs must apply in order, not race each other.
+let localeSwitchQueue: Promise<void> = Promise.resolve();
+
 // Switch the storefront preview to the edited page's language without touching the URL (VCST-5219).
 // The designer preview runs on a fixed `/designer-preview` route (vue-router base ""), so we must not
-// add a `/{lang}` prefix here; we only re-init the i18n locale and update globals.cultureName, which
-// drives content-localized GraphQL queries on the next block remount.
-async function applyPreviewLocale(cultureName?: string) {
-  if (!cultureName || cultureName === globals.cultureName) {
-    return;
-  }
+// add a `/{lang}` prefix here; we re-apply the locale through the shared seam (app messages, UI kit
+// and module bundles, number formats) and update globals.cultureName, which drives
+// content-localized GraphQL queries on the next block remount.
+function applyPreviewLocale(cultureName?: string): Promise<void> {
+  localeSwitchQueue = localeSwitchQueue.then(() => switchPreviewLocale(cultureName));
+  return localeSwitchQueue;
+}
 
-  const { supportedLanguages, initLocale, mergeLocalesMessages } = useLanguages();
-  const language = supportedLanguages.value.find((item) => item.cultureName === cultureName);
-  if (!language) {
-    return;
-  }
+async function switchPreviewLocale(rawCultureName?: string): Promise<void> {
+  try {
+    const { applyLocale, normalizeToSupportedCulture } = useLanguages();
+    const cultureName = normalizeToSupportedCulture(rawCultureName);
 
-  if (globals.i18n) {
-    await initLocale(globals.i18n, cultureName, { rewriteUrl: false });
-
-    // Merge the UI kit locale bundles for the new language, mirroring storefront boot, otherwise
-    // ui_kit.* strings stay in the initial boot language while page content uses the new locale (VCST-5219).
-    const uiKitMessages = await getUIKitLocales(FALLBACK_LOCALE, language.twoLetterLanguageName);
-    mergeLocalesMessages(globals.i18n, language.twoLetterLanguageName, uiKitMessages.messages);
-    if (language.twoLetterLanguageName !== FALLBACK_LOCALE) {
-      mergeLocalesMessages(globals.i18n, FALLBACK_LOCALE, uiKitMessages.fallbackMessages);
+    if (!cultureName || cultureName === globals.cultureName || !globals.i18n) {
+      return;
     }
+
+    await applyLocale(globals.i18n, cultureName, { rewriteUrl: false });
+    setGlobals({ cultureName });
+  } catch (error) {
+    // Never propagate: the message handler reveals the preview body right after this, and a failed
+    // locale switch must degrade to the boot language — not leave the preview permanently hidden.
+    Logger.error("Failed to apply the preview locale", error);
   }
-  setGlobals({ cultureName });
 }
 
 function scrollToSection(sectionId: string) {

--- a/client-app/plugins/builder-preview/utils.ts
+++ b/client-app/plugins/builder-preview/utils.ts
@@ -1,3 +1,5 @@
+import { LOCALE_ID_REGEX } from "@/core/constants/locale";
+
 let cachedBuilderOrigin: string | undefined;
 
 export function getBuilderOrigin() {
@@ -18,9 +20,12 @@ export function getPreviewPageId(): string | undefined {
 // Culture of the page being previewed, passed by the Page Builder admin (VCST-5219).
 // Used by the standalone `/designer-preview?pageId=…&cultureName=fr-FR` preview so the storefront
 // renders in the page's language instead of the store default.
+// The raw query value is forwarded to the pageContext request before store languages are known,
+// so anything that isn't shaped like a locale identifier is dropped here.
 export function getPreviewCultureName(): string | undefined {
   const urlParams = new URLSearchParams(globalThis.location.search);
-  return urlParams.get("cultureName") ?? undefined;
+  const cultureName = urlParams.get("cultureName");
+  return cultureName && LOCALE_ID_REGEX.test(cultureName) ? cultureName : undefined;
 }
 
 export function isPreviewMode(): boolean {

--- a/client-app/plugins/builder-preview/utils.ts
+++ b/client-app/plugins/builder-preview/utils.ts
@@ -31,3 +31,34 @@ export function getPreviewCultureName(): string | undefined {
 export function isPreviewMode(): boolean {
   return globalThis.location.pathname === "/designer-preview";
 }
+
+export type PreviewBootOptionsType = {
+  /** Whether this document is the Page Builder designer / standalone preview. */
+  isActive: boolean;
+  /** Language of the previewed page, taken from `?cultureName=`; absent unless the preview is active. */
+  cultureName?: string;
+  /**
+   * Whether the active locale may be reflected as a `/{lang}` URL prefix — `true` when the preview
+   * imposes no constraint, i.e. on a normal storefront boot. The preview itself lives on a fixed
+   * `/designer-preview` route, so prefixing it would stop vue-router's base from matching the
+   * pathname and the preview would 404. Callers take this instead of negating `isActive` themselves,
+   * so the reason stays next to the route it constrains.
+   */
+  useLocalePrefix: boolean;
+};
+
+/**
+ * Everything storefront boot needs to know about a Page Builder preview, resolved from the URL
+ * before the preview plugin is installed. Boot has to decide the locale and the router base up
+ * front, so it can't wait for the plugin — this keeps the reasoning here instead of scattering
+ * Page Builder branches across `app-runner` (VCST-5219).
+ */
+export function getPreviewBootOptions(): PreviewBootOptionsType {
+  const isActive = isPreviewMode();
+
+  return {
+    isActive,
+    cultureName: isActive ? getPreviewCultureName() : undefined,
+    useLocalePrefix: !isActive,
+  };
+}


### PR DESCRIPTION
**Proof of concept on top of #2363 — for discussion, not for merge as-is.**

Extracts a single "apply locale at runtime" contract so the builder-preview plugin stops re-implementing boot internals:

- `core/locale-loaders.ts` — keyed loader registry (`register/run/reset`; re-registering a key overwrites, so repeated boots/HMR don't accumulate duplicates)
- `useLanguages.applyLocale(i18n, cultureName, { rewriteUrl })` = `initLocale` + per-culture `numberFormats` + all registered loaders (error-isolated)
- app-runner registers the UI-kit loader once (composition root); the boot-time UI-kit merge block is deleted
- `loadModuleLocale` self-registers a `module:<name>` re-loader → runtime locale switches reload every enabled module's messages, zero changes to module inits
- plugin's `applyPreviewLocale` collapses to: `normalizeToSupportedCulture` → `applyLocale(..., { rewriteUrl: false })` → `setGlobals`; serialized via promise queue and never throws, so the preview body reveal can't be skipped by a rejected locale-chunk import
- `normalizeToSupportedCulture` accepts `fr` / `fr-fr` forms instead of silently falling back to the store default; the `/^[a-zA-Z0-9-]+$/` locale guard is now one shared `LOCALE_ID_REGEX`

Verified: `vue-tsc --build --force` ✔, eslint error set identical to the base-branch baseline, 31/31 `useLanguages` unit tests ✔, `yarn build` ✔
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.53.0-pr-2374-bd79-bd79bab8.zip