### PR TITLE
chore(VCST-5159): drop core-types contract check from `yarn validate` during MF pilot

### DIFF
--- a/client-app/modules/federated/TODO.md
+++ b/client-app/modules/federated/TODO.md
@@ -86,10 +86,17 @@ section of the discovery spec.
 type-check — including from the real tarball), but only manually. Remaining:
 
 - [ ] Wire the scaffold → install → build cycle into CI (locks the plugin contract).
-- [ ] **Host PR CI: fetch the `dev` baseline** for `validate:core-types` — the
-      removal-detection gate (`compareContractToBase`) degrades to a loud warning when
-      the checkout is too shallow to see the base branch's committed contract. Needs
-      `fetch-depth: 0` (or an explicit `git fetch origin dev`) in the theme CI checkout.
+- [ ] **Re-wire `validate:core-types` into `yarn validate` when MF ships.** It was
+      removed from the aggregate `validate` script during the pilot (no plugin consumes
+      the contract yet) so that unrelated PRs — e.g. a routine GraphQL-types regen, which
+      reaches the contract through the facade's `apolloClient`/`graphqlClient`
+      re-export — aren't blocked by contract drift. Once a plugin depends on the contract,
+      add `&& yarn validate:core-types` back to the `validate` script in `package.json`.
+- [ ] **Host PR CI: fetch the `dev` baseline** for `validate:core-types` (only matters
+      once the check above is re-wired into CI) — the removal-detection gate
+      (`compareContractToBase`) degrades to a loud warning when the checkout is too
+      shallow to see the base branch's committed contract. Needs `fetch-depth: 0` (or an
+      explicit `git fetch origin dev`) in the theme CI checkout.
 - [ ] A live `loadRemote` smoke against a running host build.
 - [ ] When #2 lands: coverage for the new `resolveRemotes` (multi-source, precedence truth
       table, name-collision dedup) and a **guard test for the load-bearing ordering

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "validate:types": "yarn precheck && vue-tsc --build --force",
     "validate:dependencies": "yarn precheck && depcruise client-app",
     "validate:core-types": "yarn precheck && node client-app/core-api/build-types.mjs --check",
-    "validate": "yarn precheck && yarn validate:types && yarn validate:dependencies && yarn validate:core-types",
+    "validate": "yarn precheck && yarn validate:types && yarn validate:dependencies",
     "commitlint": "yarn precheck && commitlint --edit",
     "lint-staged": "yarn precheck && lint-staged",
     "lint": "yarn precheck && eslint . --cache --cache-location node_modules/.cache/.eslintcache --cache-strategy content",


### PR DESCRIPTION
## What

Remove `validate:core-types` from the aggregate `yarn validate` script so it no longer runs in CI while Module Federation is a pilot. The standalone `yarn validate:core-types` script is kept — run it by hand after a facade change.

```diff
- "validate": "... && yarn validate:dependencies && yarn validate:core-types",
+ "validate": "... && yarn validate:dependencies",
```

## Why

`validate:core-types` regenerates the `@vc-frontend/core` type contract and fails if the committed `contract/index.d.ts` differs. The facade re-exports `apolloClient`/`graphqlClient`, so the generated contract **inlines the whole GraphQL types graph**.

Consequence: any **unrelated** PR that regenerates GraphQL types — a routine chore here (`update backend packages & graphql types`, and feature branches touching the schema) — makes the committed contract stale and **fails CI** with:

```
[build-types] FAILED: committed contract/index.d.ts is stale — run `yarn build:core-types` and commit the result.
```

This already hit an unrelated branch (VCST-5239, org-scoped roles), which had to regenerate and commit the contract just to get CI green. **No plugin consumes the contract yet**, so this drift is harmless during the pilot — the gate is pure friction for everyone else.

## Scope / safety

- **Runtime unchanged.** This only removes a CI/build step. MF stays off by default; no loader, bundle, or `yarn dev` behavior changes.
- The check still exists and can be run manually (`yarn validate:core-types`), and `yarn build:core-types` is untouched (still regenerates + version-bumps).
- Docs (`core-api/README.md`, `modules/federated/README.md`) and `modules/federated/TODO.md` updated with a **TODO to re-add `&& yarn validate:core-types` to `validate` when MF ships** (i.e. once a plugin actually depends on the contract).

## Jira

https://virtocommerce.atlassian.net/browse/VCST-5159
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.53.0-pr-2377-b438-b43820e7.zip