### PR TITLE
test(VCST-5414): test workflows from branch

### DIFF
--- a/.github/workflows/deploy-cloud.yml
+++ b/.github/workflows/deploy-cloud.yml
@@ -97,14 +97,14 @@ jobs:
     steps:
 
     - name: Read deployment config
-      uses: VirtoCommerce/vc-github-actions/get-deploy-param@master
+      uses: VirtoCommerce/.github/actions/get-deploy-param@VCST-5414
       id: deployConfig
       with:
         envName: ${{ inputs.environmentId }}
         deployConfigPath: .deployment/theme/cloudDeploy.json
 
     - name: Start deployment
-      uses: VirtoCommerce/vc-github-actions/gh-deployments@master
+      uses: VirtoCommerce/.github/actions/gh-deployments@VCST-5414
       id: deployment
       with:
         step: start
@@ -113,7 +113,7 @@ jobs:
         no_override: false
 
     - name: Deploy to ${{ steps.deployConfig.outputs.environmentName }}
-      uses: VirtoCommerce/vc-github-actions/create-deploy-pr@master
+      uses: VirtoCommerce/.github/actions/create-deploy-pr@VCST-5414
       with:
         githubToken: ${{ env.GITHUB_TOKEN }}
         deployRepo: ${{ steps.deployConfig.outputs.deployRepo }}
@@ -146,7 +146,7 @@ jobs:
       run: echo "DEPLOY_STATE=failed"  >> $GITHUB_ENV
 
     - name: Update GitHub deployment status
-      uses: VirtoCommerce/vc-github-actions/gh-deployments@master
+      uses: VirtoCommerce/.github/actions/gh-deployments@VCST-5414
       if: always()
       with:
         step: finish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,6 @@ on:
 
 jobs:
   release:
-    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.39
+    uses: VirtoCommerce/.github/.github/workflows/release.yml@VCST-5414
     secrets:
       envPAT: ${{ secrets.REPO_TOKEN }}

--- a/.github/workflows/storybook-ci.yml
+++ b/.github/workflows/storybook-ci.yml
@@ -59,7 +59,7 @@ jobs:
           fetch-depth: 0
 
       - name: Get Image Version
-        uses: VirtoCommerce/vc-github-actions/get-image-version@master
+        uses: VirtoCommerce/.github/actions/get-image-version@VCST-5414
         with:
           projectType: theme
         id: image
@@ -118,7 +118,7 @@ jobs:
       - name: Publish to Blob
         if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/master')}}
         id: blobRelease
-        uses: VirtoCommerce/vc-github-actions/publish-blob-release@master
+        uses: VirtoCommerce/.github/actions/publish-blob-release@VCST-5414
         with:
           blobSAS: ${{ secrets.BLOB_TOKEN }}
           blobUrl: ${{ vars.BLOB_URL }}
@@ -148,7 +148,7 @@ jobs:
           tags: ${{ steps.urls.outputs.DOCKER_URL }}${{ env.DOCKER_TAG }},${{ steps.urls.outputs.DOCKER_URL }}${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/dev' && 'dev-latest' || 'latest'}}
 
       - name: Parse Jira Keys from All Commits
-        uses: VirtoCommerce/vc-github-actions/get-jira-keys@master
+        uses: VirtoCommerce/.github/actions/get-jira-keys@VCST-5414
         if: always()
         id: jira_keys
         with:

--- a/.github/workflows/theme-ci.yml
+++ b/.github/workflows/theme-ci.yml
@@ -61,14 +61,14 @@ jobs:
           fetch-depth: 0
 
       - name: Get Image Version
-        uses: VirtoCommerce/vc-github-actions/get-image-version@master
+        uses: VirtoCommerce/.github/actions/get-image-version@VCST-5414
         with:
           projectType: theme
         id: image
 
       - name: Get changelog
         id: changelog
-        uses: VirtoCommerce/vc-github-actions/changelog-generator@master
+        uses: VirtoCommerce/.github/actions/changelog-generator@VCST-5414
 
       - name: Set release VERSION_SUFFIX
         run: |
@@ -144,14 +144,14 @@ jobs:
       - name: Publish to Blob
         if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/master')}}
         id: blobRelease
-        uses: VirtoCommerce/vc-github-actions/publish-blob-release@master
+        uses: VirtoCommerce/.github/actions/publish-blob-release@VCST-5414
         with:
           blobSAS: ${{ secrets.BLOB_TOKEN }}
           blobUrl: ${{ vars.BLOB_URL }}
 
       - name: Add link to PR
         if: ${{ github.event_name == 'pull_request' }}
-        uses: VirtoCommerce/vc-github-actions/publish-artifact-link@master
+        uses: VirtoCommerce/.github/actions/publish-artifact-link@VCST-5414
         with:
           artifactUrl: ${{ steps.blobRelease.outputs.packageUrl }}
           repoOrg: ${{ github.repository_owner }}
@@ -190,7 +190,7 @@ jobs:
           fi
 
       - name: Parse Jira Keys from All Commits
-        uses: VirtoCommerce/vc-github-actions/get-jira-keys@master
+        uses: VirtoCommerce/.github/actions/get-jira-keys@VCST-5414
         if: always()
         id: jira_keys
         with:
@@ -225,7 +225,7 @@ jobs:
 
       - name: Update Jira Tasks with Release Number
         if: ${{ github.ref == 'refs/heads/master' }}
-        uses: VirtoCommerce/vc-github-actions/update-jira-tasks-with-release-number@master
+        uses: VirtoCommerce/.github/actions/update-jira-tasks-with-release-number@VCST-5414
         with:
           ghRepository: ${{ github.repository }}
           ghReleaseTag: ${{ steps.image.outputs.prefix }}
@@ -254,7 +254,7 @@ jobs:
     needs: ci
     if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
         (github.event_name == 'workflow_dispatch') || (github.base_ref == 'dev') && (github.event_name == 'pull_request') }}
-    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.39
+    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@VCST-5414
     with:
       installModules: 'false'
       installCustomModule: 'false'

--- a/.github/workflows/theme-release-hotfix.yml
+++ b/.github/workflows/theme-release-hotfix.yml
@@ -29,15 +29,15 @@ jobs:
         uses: warchant/setup-sonar-scanner@911ef81b14b267a261d70ac94e43d3c822a709d5 # v10
 
       - name: Install VirtoCommerce.GlobalTool
-        uses: VirtoCommerce/vc-github-actions/setup-vcbuild@master
+        uses: VirtoCommerce/.github/actions/setup-vcbuild@VCST-5414
 
       - name: Setup Git Credentials
-        uses: VirtoCommerce/vc-github-actions/setup-git-credentials-github@master
+        uses: VirtoCommerce/.github/actions/setup-git-credentials-github@VCST-5414
         with:
           githubToken: ${{ secrets.REPO_TOKEN }}
 
       - name: Get Image Version
-        uses: VirtoCommerce/vc-github-actions/get-image-version@master
+        uses: VirtoCommerce/.github/actions/get-image-version@VCST-5414
         id: image
         with:
           projectType: "theme"
@@ -87,7 +87,7 @@ jobs:
 
       - name: Publish to Blob
         id: blobRelease
-        uses: VirtoCommerce/vc-github-actions/publish-blob-release@master
+        uses: VirtoCommerce/.github/actions/publish-blob-release@VCST-5414
         with:
           blobSAS: ${{ secrets.BLOB_TOKEN }}
 


### PR DESCRIPTION
## Description

## References
### Jira-link:
<!-- Put link to your task in Jira here -->https://virtocommerce.atlassian.net/browse/VCST-5414
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.53.0-pr-2379-52ca-52ca960e.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only workflow references but affects build, release, deploy, and Jira integration across all main pipelines; a bad branch ref could break CI until reverted.
> 
> **Overview**
> **CI/CD workflows are repointed** from the legacy `VirtoCommerce/vc-github-actions/*@master` composite actions to the consolidated `VirtoCommerce/.github/actions/*@VCST-5414` refs, so theme, Storybook, cloud deploy, hotfix, and release pipelines exercise the new shared actions on branch `VCST-5414`.
> 
> **Reusable workflows** that call into `VirtoCommerce/.github` are updated the same way: `release.yml` and `theme-ci`’s `pytest-tests` job now use `@VCST-5414` instead of pinned tags like `@v3.800.39`. Step inputs and job logic are unchanged—only the `uses:` sources move.
> 
> Affected areas include versioning/changelog, blob publish, Jira keys, deploy PR creation, GitHub deployment status, artifact PR links, and vcbuild/git credential setup across `deploy-cloud.yml`, `theme-ci.yml`, `storybook-ci.yml`, `theme-release-hotfix.yml`, and `release.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52ca960e324b7a89b0f9fea348b04f20d0694ecd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->