### PR TITLE
perf(VCST-4400): load icons as hashed assets, not eager JS registry [example]

### DIFF
--- a/client-app/ui-kit/utilities/icons.test.ts
+++ b/client-app/ui-kit/utilities/icons.test.ts
@@ -1,6 +1,26 @@
-import { afterEach, describe, it, expect } from "vitest";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { afterAll, afterEach, beforeAll, describe, it, expect, vi } from "vitest";
 import { resolveIconName } from "./icon-aliases";
 import { resolveIcon, loadIconRaw, setDefaultIconVariant } from "./icons";
+
+beforeAll(() => {
+  // Icons resolve to asset URLs and are fetched at runtime; there is no server
+  // under vitest, so serve them from disk.
+  vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+    const url = String(input).replace(/^\/@fs/, "");
+    const filePath = url.startsWith("/") && !url.startsWith("//") ? path.join(process.cwd(), url) : url;
+    try {
+      return new Response(await readFile(filePath, "utf8"), { status: 200 });
+    } catch {
+      return new Response("", { status: 404 });
+    }
+  });
+});
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+});
 
 afterEach(() => {
   setDefaultIconVariant("outline");

--- a/client-app/ui-kit/utilities/icons.ts
+++ b/client-app/ui-kit/utilities/icons.ts
@@ -4,33 +4,53 @@ import { resolveIconName } from "./icon-aliases";
 
 export type IconVariantType = "solid" | "outline";
 
-const solidLoaders = import.meta.glob("../icons/solid/*.svg", {
-  query: "?raw",
+const solidUrls = import.meta.glob("../icons/solid/*.svg", {
+  query: "?url",
   import: "default",
-}) as Record<string, () => Promise<string>>;
+  eager: true,
+}) as Record<string, string>;
 
-const outlineLoaders = import.meta.glob("../icons/outline/*.svg", {
-  query: "?raw",
+const outlineUrls = import.meta.glob("../icons/outline/*.svg", {
+  query: "?url",
   import: "default",
-}) as Record<string, () => Promise<string>>;
+  eager: true,
+}) as Record<string, string>;
 
-function toMap(loaders: Record<string, () => Promise<string>>): Map<string, () => Promise<string>> {
+function toMap(urls: Record<string, string>): Map<string, () => Promise<string>> {
   const map = new Map<string, () => Promise<string>>();
 
-  for (const [path, loader] of Object.entries(loaders)) {
+  for (const [path, url] of Object.entries(urls)) {
     // eslint-disable-next-line sonarjs/null-dereference -- path is a typed string key; the rule is a false positive here
     const fileName = path.split("/").pop()?.replace(".svg", "");
 
     if (fileName) {
-      map.set(fileName, loader);
+      // Memoize per icon: import() was deduped by the module cache, fetch() is not,
+      // so without this every icon instance on a page would issue its own request.
+      let cached: Promise<string> | undefined;
+
+      map.set(fileName, () => {
+        cached ??= fetch(url)
+          .then((response) => {
+            if (!response.ok) {
+              throw new Error(`HTTP ${response.status} for ${url}`);
+            }
+            return response.text();
+          })
+          .catch((error: unknown) => {
+            // Don't cache failures — allow a retry on the next render.
+            cached = undefined;
+            throw error;
+          });
+        return cached;
+      });
     }
   }
 
   return map;
 }
 
-const solidMap = toMap(solidLoaders);
-const outlineMap = toMap(outlineLoaders);
+const solidMap = toMap(solidUrls);
+const outlineMap = toMap(outlineUrls);
 
 let defaultIconVariant: IconVariantType = "outline";
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -102,6 +102,9 @@ export default defineConfig(({ command, mode }): UserConfig => {
       target: browserslistToEsbuild(),
       emptyOutDir: true,
       sourcemap: true,
+      // Icon SVGs must stay real assets (fetched on demand by VcIcon), never inlined
+      // as data: URIs into the eager registry.
+      assetsInlineLimit: (filePath) => (filePath.includes("/ui-kit/icons/") ? false : undefined),
       rollupOptions: {
         output: {
           manualChunks(id = "") {


### PR DESCRIPTION
> **Draft / example** — a demonstration of the icon bundle-size optimization discussed in [#2382](https://github.com/VirtoCommerce/vc-frontend/pull/2382). Targets `feat/VCST-4400` so the diff is *only* the icon-loading change. Not meant to merge as-is — cherry-pick / fold into #2382 as you see fit.

## What
Load the 2,689 icons as **hashed static assets fetched on demand** instead of lazy `?raw` JS chunks + an eager registry of import wrappers.

## Why
The current `import.meta.glob(..., { query: "?raw" })` in `client-app/ui-kit/utilities/icons.ts` (lines ~7–15) emits a registry of all 2,689 dynamic-import wrappers into the eager `index.js` (VcIcon is app-wide) **and** turns each SVG into its own JS chunk.

## Changes
1. **`icons.ts`** — globs switched to `query: "?url", eager: true` → registry becomes tiny name→URL strings.
2. **`icons.ts`** — `toMap` wraps each URL in a **memoized** `fetch` loader (import() was deduped by the module cache; fetch() isn't — without memoization each VcIcon instance re-requests). Failures aren't cached, so a later render retries. Downstream API/sanitize/`VcIcon` unchanged.
3. **`vite.config.ts`** — `assetsInlineLimit` callback excludes `/ui-kit/icons/` so tiny SVGs aren't inlined as data-URIs back into the eager bundle.
4. **`icons.test.ts`** — `fetch` stub for the vitest env.

## Results
| | dev | #2382 | this |
|---|---|---|---|
| main `index.js` (gzip) | 418 KB | 605 KB | **317 KB** |
| JS chunks | 655 | 3,016 | **327** |
| cold Slow-4G FCP (median, 5 runs) | 9.56 s | 10.72 s | **9.06 s** |
| cold Slow-4G LCP | 12.39 s | 13.52 s | **11.92 s** |

## Verified
- `vue-tsc --build` clean · unit tests 31/31 · runtime checked in `yarn dev` + `yarn preview` (icons render, requests dedupe to 1/icon, no console errors).

Full rationale + perf methodology in [#2382 comment](https://github.com/VirtoCommerce/vc-frontend/pull/2382#issuecomment-4990179432).
