### PR TITLE
chore(VCST-5516): derive CSP frame-ancestors from APP_BACKEND_URL

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,6 +29,14 @@ function getProxy(target: ProxyOptions["target"], options: Omit<ProxyOptions, "t
   };
 }
 
+// Builds the dev-server `Content-Security-Policy: frame-ancestors` directive. The backend host is
+// environment-specific, so it comes from APP_BACKEND_URL (same source as the proxy target) instead of
+// being hardcoded. builder.io is a fixed external host used by the Page Builder integration.
+function getContentSecurityPolicy(): string {
+  const frameAncestors = ["'self'", process.env.APP_BACKEND_URL, "https://builder.io"].filter(Boolean);
+  return `frame-ancestors ${frameAncestors.join(" ")};`;
+}
+
 function getBackendProxy(): Record<string, ProxyOptions> {
   return {
     "^/api": getProxy(process.env.APP_BACKEND_URL),
@@ -125,7 +133,7 @@ export default defineConfig(({ command, mode }): UserConfig => {
       port: 3000,
       cors: true,
       headers: {
-        "Content-Security-Policy": "frame-ancestors 'self' https://localhost:5001 https://builder.io;",
+        "Content-Security-Policy": getContentSecurityPolicy(),
         "Cross-Origin-Resource-Policy": "cross-origin",
         "Cross-Origin-Embedder-Policy": "unsafe-none",
       },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -33,7 +33,10 @@ function getProxy(target: ProxyOptions["target"], options: Omit<ProxyOptions, "t
 // environment-specific, so it comes from APP_BACKEND_URL (same source as the proxy target) instead of
 // being hardcoded. builder.io is a fixed external host used by the Page Builder integration.
 function getContentSecurityPolicy(): string {
-  const frameAncestors = ["'self'", process.env.APP_BACKEND_URL, "https://builder.io"].filter(Boolean);
+  // Normalize to an origin so a trailing slash/path or unexpected scheme in APP_BACKEND_URL can't
+  // produce an invalid CSP host-source (e.g. ".../store"); falls back gracefully if the var is unset.
+  const backendOrigin = process.env.APP_BACKEND_URL ? new URL(process.env.APP_BACKEND_URL).origin : undefined;
+  const frameAncestors = ["'self'", backendOrigin, "https://builder.io"].filter(Boolean);
   return `frame-ancestors ${frameAncestors.join(" ")};`;
 }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,12 +29,10 @@ function getProxy(target: ProxyOptions["target"], options: Omit<ProxyOptions, "t
   };
 }
 
-// Builds the dev-server `Content-Security-Policy: frame-ancestors` directive. The backend host is
-// environment-specific, so it comes from APP_BACKEND_URL (same source as the proxy target) instead of
-// being hardcoded. builder.io is a fixed external host used by the Page Builder integration.
+// Dev-server CSP frame-ancestors: backend host comes from APP_BACKEND_URL (like the proxy);
+// builder.io is a fixed Page Builder host.
 function getContentSecurityPolicy(): string {
-  // Normalize to an origin so a trailing slash/path or unexpected scheme in APP_BACKEND_URL can't
-  // produce an invalid CSP host-source (e.g. ".../store"); falls back gracefully if the var is unset.
+  // Use origin only — strips a trailing slash/path so the CSP host-source stays valid.
   const backendOrigin = process.env.APP_BACKEND_URL ? new URL(process.env.APP_BACKEND_URL).origin : undefined;
   const frameAncestors = ["'self'", backendOrigin, "https://builder.io"].filter(Boolean);
   return `frame-ancestors ${frameAncestors.join(" ")};`;


### PR DESCRIPTION
## Description

The dev-server `Content-Security-Policy` header in `vite.config.ts` hardcoded the backend host (`https://localhost:5001`) in the `frame-ancestors` directive. Because it was a constant, it stayed `localhost:5001` even when the dev server pointed at a different backend via `APP_BACKEND_URL` (e.g. a remote QA host or a different Docker port) — so framing the storefront from that backend (Page Builder / platform preview) was blocked by CSP. It was also inconsistent with the proxy in the same file, which already reads `process.env.APP_BACKEND_URL`.

This PR derives the `frame-ancestors` directive from `APP_BACKEND_URL` (same source as the proxy target) via a small `getContentSecurityPolicy()` helper, so the CSP tracks the configured backend. `builder.io` stays hardcoded — it's a fixed external Page Builder host, not environment-specific.

The backend value is normalized with `new URL(APP_BACKEND_URL).origin` so a trailing slash, path, or unexpected scheme in the env var can't emit an invalid CSP host-source (e.g. `.../store`). It falls back gracefully to `'self' https://builder.io` when the var is unset.

Scope note: `server.headers` applies to the dev server (`serve`) only — no effect on production builds or `preview`.

With the default `APP_BACKEND_URL=https://localhost:5001`, the emitted header is byte-for-byte identical to before:
`frame-ancestors 'self' https://localhost:5001 https://builder.io;` — no behavior change for the default setup.

## References
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5516
### Artifact URL: