### PR TITLE
chore(codegen): make missing-module output clear and exit codes meaningful

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,16 +226,21 @@ yarn generate:graphql-types
 
 Generates the `types.ts` files separately for `The Core App` and independent modules.
 
-Every schema endpoint is probed before generation. A module that is not installed on the target
-`APP_BACKEND_URL` answers `404`, and only that answer counts as "not installed": such a module is reported as
-`skipped, schema not available`, its committed `types.ts` is left untouched, the remaining modules are still
-generated and the command exits with `0` — there is no need to comment the module out in
-`scripts/graphql-codegen/generator.ts`.
+Every schema endpoint is probed before generation, and a `404` is the only answer treated as "the module is
+not installed on the target `APP_BACKEND_URL`". Such a module is reported as `skipped, schema not available`,
+its committed `types.ts` is left untouched, the remaining modules are still generated and the command exits
+with `0` — there is no need to comment the module out in `scripts/graphql-codegen/generator.ts`.
 
-Any other answer means the endpoint is there, so a generation error is reported instead of skipped and the
-command exits with `1`. That covers a protected or broken endpoint (`401`, `500`, an HTML page) and `.graphql`
-queries asking for fields the schema no longer has. A missing core schema aborts the run right away, as every
-module would fail with it.
+A `404` is strong evidence, not proof: a scoped endpoint that was renamed, or is missing for any other
+reason, answers the same way and is skipped too. The committed `types.ts` is then reused without being
+validated against any schema, which is why the module name and its endpoint are printed. A module that is
+skipped and has no committed `types.ts` at all is reported as a failure instead, since there is nothing to
+fall back on.
+
+Any other answer means the endpoint is there, so generation runs and anything it hits is reported as a
+failure with exit code `1` instead of being skipped — a protected or broken endpoint (`401`, `500`, an HTML
+page), or `.graphql` queries asking for fields the schema no longer has. A missing core schema aborts the run
+right away, as every module would fail with it.
 
 ## Dependency Analysis
 

--- a/README.md
+++ b/README.md
@@ -225,7 +225,17 @@ yarn generate:graphql-types
 ```
 
 Generates the `types.ts` files separately for `The Core App` and independent modules.
-If independent modules are not installed on `The Platform`, types can still be safely generated.
+
+Every schema endpoint is probed before generation. A module that is not installed on the target
+`APP_BACKEND_URL` answers `404`, and only that answer counts as "not installed": such a module is reported as
+`skipped, schema not available`, its committed `types.ts` is left untouched, the remaining modules are still
+generated and the command exits with `0` — there is no need to comment the module out in
+`scripts/graphql-codegen/generator.ts`.
+
+Any other answer means the endpoint is there, so a generation error is reported instead of skipped and the
+command exits with `1`. That covers a protected or broken endpoint (`401`, `500`, an HTML page) and `.graphql`
+queries asking for fields the schema no longer has. A missing core schema aborts the run right away, as every
+module would fail with it.
 
 ## Dependency Analysis
 

--- a/client-app/modules/README.md
+++ b/client-app/modules/README.md
@@ -96,6 +96,13 @@ The `scripts/graphql-codegen/generator.ts` file also plays a crucial role in han
   },
 ```
 
+Leave the entry in place even when the backend module is missing from the environment you generate
+against: such an endpoint answers `404`, so the module is reported as skipped, its committed
+`types.ts` is reused untouched and every other module is still generated. Anything else that goes
+wrong — an endpoint that answers but breaks generation, or a module that is skipped without having a
+committed `types.ts` to fall back on — fails the command. See "Types generation" in the root
+`README.md`.
+
 ---
 
 ### Registering Routes

--- a/client-app/modules/README.md
+++ b/client-app/modules/README.md
@@ -99,8 +99,8 @@ The `scripts/graphql-codegen/generator.ts` file also plays a crucial role in han
 Leave the entry in place even when the backend module is missing from the environment you generate
 against: such an endpoint answers `404`, so the module is reported as skipped, its committed
 `types.ts` is reused untouched and every other module is still generated. Anything else that goes
-wrong — an endpoint that answers but breaks generation, or a module that is skipped without having a
-committed `types.ts` to fall back on — fails the command. See "Types generation" in the root
+wrong — an endpoint that answers but breaks generation, or an endpoint that answers `404` while the
+module has no committed `types.ts` to fall back on — fails the command. See "Types generation" in the root
 `README.md`.
 
 ---

--- a/scripts/graphql-codegen/generator.ts
+++ b/scripts/graphql-codegen/generator.ts
@@ -39,8 +39,7 @@ if (
 }
 
 // if a module does not have separated schema - use `core.schemaPath`
-// a module that is not installed on The Platform is reported as skipped and keeps the run green,
-// so there is no need to comment it out to get types for the other modules
+// a module missing from the target environment is skipped, so it need not be commented out
 const independentModules: ModuleType[] = [
   {
     name: "CustomerReviews",
@@ -160,7 +159,7 @@ async function runCodegen() {
   });
 
   if (coreOutcome.status !== "generated") {
-    // Every module request would fail the same way without the core schema, so there is nothing to continue with.
+    // Without the core schema every module would fail the same way.
     reportAbortedCore(coreOutcome);
     process.exitCode = 1;
     return;
@@ -168,8 +167,7 @@ async function runCodegen() {
 
   reportOutcome(coreOutcome);
 
-  // Reported as each module settles, so a slow environment keeps showing progress. The array itself
-  // stays in declaration order, which is what the summary reads.
+  // Reported as each module settles; the array keeps declaration order for the summary.
   const moduleOutcomes = await Promise.all(
     independentModules.map((module) =>
       generateTypes({
@@ -188,8 +186,7 @@ async function runCodegen() {
 
   printSummary([coreOutcome, ...moduleOutcomes]);
 
-  // Skipped modules are a normal state of a partially installed environment and keep the run green,
-  // a module that broke while its schema was reachable does not.
+  // A partially installed environment is normal and stays green; a broken module does not.
   if (moduleOutcomes.some(({ status }) => status === "failed")) {
     process.exitCode = 1;
   }
@@ -210,11 +207,9 @@ async function generateTypes({
   typesPath: string;
 }): Promise<OutcomeType> {
   if (await isSchemaEndpointAbsent(schemaUrl)) {
-    // The bare fact, so that both a skipped module and an aborted core can phrase it their own way.
     const reason = `"${schemaUrl}" answered 404`;
 
-    // Falling back to a committed types.ts is what makes skipping safe. Without one there is nothing
-    // to fall back on: the module's imports cannot type-check, so this is a failure, not a skip.
+    // Reusing a committed types.ts is what makes skipping safe; without one there is nothing to reuse.
     return existsSync(typesPath)
       ? { name, typesPath, status: "skipped", reason }
       : {
@@ -248,7 +243,6 @@ async function generateTypes({
   }
 }
 
-/** Returns the outcome so it can be reported inline while the results are being collected. */
 function reportOutcome(outcome: OutcomeType): OutcomeType {
   switch (outcome.status) {
     case "generated":
@@ -270,8 +264,7 @@ function reportSuccess({ name, typesPath }: OutcomeType): void {
 }
 
 function reportSkip({ name, typesPath, reason }: OutcomeType): void {
-  // 404 is what The Platform answers for a module it does not have, but it is evidence rather than
-  // proof — a mistyped or renamed endpoint answers the same way, so the wording stays factual.
+  // 404 is evidence, not proof: a renamed endpoint answers the same way, so the wording stays factual.
   console.warn(
     `${YELLOW}⚠${RESET} ${BOLD}${name}${RESET}: no schema at its endpoint, module skipped as not installed — keeping the committed "${typesPath}"\n  ${reason}`,
   );
@@ -298,7 +291,7 @@ function reportAbortedCore(outcome: OutcomeType): void {
 
 function printSummary(outcomes: OutcomeType[]): void {
   const { generated, skipped, failed } = groupByStatus(outcomes);
-  // A rule above the heading instead of a boxed frame: module lists are long and would break side borders.
+  // A rule above the heading rather than a box: module lists are long and would break side borders.
   const names = (group: OutcomeType[]) => group.map(({ name }) => name).join(", ");
 
   console.log(`\n${"━".repeat(SUMMARY_WIDTH)}\n${BOLD}GraphQL types generation summary${RESET}`);

--- a/scripts/graphql-codegen/generator.ts
+++ b/scripts/graphql-codegen/generator.ts
@@ -211,7 +211,18 @@ async function generateTypes({
 }): Promise<OutcomeType> {
   if (await isSchemaEndpointAbsent(schemaUrl)) {
     // The bare fact, so that both a skipped module and an aborted core can phrase it their own way.
-    return { name, typesPath, status: "skipped", reason: `"${schemaUrl}" answered 404` };
+    const reason = `"${schemaUrl}" answered 404`;
+
+    // Falling back to a committed types.ts is what makes skipping safe. Without one there is nothing
+    // to fall back on: the module's imports cannot type-check, so this is a failure, not a skip.
+    return existsSync(typesPath)
+      ? { name, typesPath, status: "skipped", reason }
+      : {
+          name,
+          typesPath,
+          status: "failed",
+          error: new Error(`${reason} and "${typesPath}" has never been generated`),
+        };
   }
 
   try {
@@ -259,12 +270,10 @@ function reportSuccess({ name, typesPath }: OutcomeType): void {
 }
 
 function reportSkip({ name, typesPath, reason }: OutcomeType): void {
-  const consequence = existsSync(typesPath)
-    ? `keeping the committed "${typesPath}"`
-    : `"${typesPath}" is missing, imports from this module will not type-check`;
-
+  // 404 is what The Platform answers for a module it does not have, but it is evidence rather than
+  // proof — a mistyped or renamed endpoint answers the same way, so the wording stays factual.
   console.warn(
-    `${YELLOW}⚠${RESET} ${BOLD}${name}${RESET}: not installed on The Platform, module skipped — ${consequence}\n  ${reason}`,
+    `${YELLOW}⚠${RESET} ${BOLD}${name}${RESET}: no schema at its endpoint, module skipped as not installed — keeping the committed "${typesPath}"\n  ${reason}`,
   );
 }
 

--- a/scripts/graphql-codegen/generator.ts
+++ b/scripts/graphql-codegen/generator.ts
@@ -1,16 +1,28 @@
+import { existsSync } from "node:fs";
 import { generate } from "@graphql-codegen/cli";
+import {
+  addExtension,
+  describeErrorDetails,
+  groupByStatus,
+  isSchemaEndpointAbsent,
+  normalizeBackendUrl,
+} from "./utils.js";
+import type { ModuleType, OutcomeType } from "./utils.js";
 
-type ModuleType = {
-  name: string;
-  apiPath: string;
-  schemaPath: string;
-  requiredCommonFragments?: string[]; // Specific core fragment files that module depends on
-};
+const GREEN = "\x1b[32m";
+const YELLOW = "\x1b[33m";
+const RED = "\x1b[31m";
+const BOLD = "\x1b[1m";
+const RESET = "\x1b[0m";
+
+const SUMMARY_WIDTH = 64;
+
+const backendUrl = normalizeBackendUrl(process.env.APP_BACKEND_URL);
 
 const core = {
   apiPath: "client-app/core/api/graphql",
   commonFragmentsPath: "client-app/core/api/graphql/common/fragments",
-  schemaPath: `${process.env.APP_BACKEND_URL}/graphql`,
+  schemaPath: `${backendUrl}/graphql`,
   clientDirectivesPath: "client-app/core/api/graphql/_clientDirectives.graphql",
 } as const;
 
@@ -19,29 +31,31 @@ const core = {
 // To enable, set LOCAL_DEV_ALLOW_INSECURE_TLS="true" in your environment in addition to NODE_ENV="development".
 if (
   process.env.NODE_ENV === "development" &&
-  process.env.APP_BACKEND_URL?.startsWith("https://localhost") &&
+  // eslint-disable-next-line sonarjs/null-dereference -- false positive: normalizeBackendUrl always returns a string
+  backendUrl.startsWith("https://localhost") &&
   process.env.LOCAL_DEV_ALLOW_INSECURE_TLS === "true"
 ) {
   process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
 }
 
 // if a module does not have separated schema - use `core.schemaPath`
-// if a module not used and not installed on The Platform - remove it to avoid console error
+// a module that is not installed on The Platform is reported as skipped and keeps the run green,
+// so there is no need to comment it out to get types for the other modules
 const independentModules: ModuleType[] = [
   {
     name: "CustomerReviews",
     apiPath: "client-app/modules/customer-reviews/api/graphql",
-    schemaPath: `${process.env.APP_BACKEND_URL}/graphql/customerReviews`,
+    schemaPath: `${backendUrl}/graphql/customerReviews`,
   },
   {
     name: "PushMessages",
     apiPath: "client-app/modules/push-messages/api/graphql",
-    schemaPath: `${process.env.APP_BACKEND_URL}/graphql/pushMessages`,
+    schemaPath: `${backendUrl}/graphql/pushMessages`,
   },
   {
     name: "Quotes",
     apiPath: "client-app/modules/quotes/api/graphql",
-    schemaPath: `${process.env.APP_BACKEND_URL}/graphql/quote`,
+    schemaPath: `${backendUrl}/graphql/quote`,
     // Include specific core fragments that quotes module uses
     requiredCommonFragments: [
       `${core.commonFragmentsPath}/money.graphql`,
@@ -51,30 +65,28 @@ const independentModules: ModuleType[] = [
   {
     name: "BackInStock",
     apiPath: "client-app/modules/back-in-stock/api/graphql",
-    schemaPath: `${process.env.APP_BACKEND_URL}/graphql/back-in-stock`,
+    schemaPath: `${backendUrl}/graphql/back-in-stock`,
   },
   {
     name: "News",
     apiPath: "client-app/modules/news/api/graphql",
-    schemaPath: `${process.env.APP_BACKEND_URL}/graphql/news`,
+    schemaPath: `${backendUrl}/graphql/news`,
   },
   {
     name: "Loyalty",
     apiPath: "client-app/modules/loyalty/api/graphql",
-    schemaPath: `${process.env.APP_BACKEND_URL}/graphql/loyalty`,
+    schemaPath: `${backendUrl}/graphql/loyalty`,
   },
   {
     name: "SalesRep",
     apiPath: "client-app/modules/sales-rep/api/graphql",
-    // The sales-rep backend module (VirtoCommerce.SalesRep) exposes a scoped schema at
-    // /graphql/sales-rep. Envs without the module installed just log an error (allSettled).
-    schemaPath: `${process.env.APP_BACKEND_URL}/graphql/sales-rep`,
+    schemaPath: `${backendUrl}/graphql/sales-rep`,
   },
   /* EXPERIMENTAL FEATURE
   {
     name: "PurchaseRequests",
     apiPath: "client-app/modules/purchase-requests/api/graphql",
-    schemaPath: `${process.env.APP_BACKEND_URL}/graphql/aiDocumentProcessing`,
+    schemaPath: `${backendUrl}/graphql/aiDocumentProcessing`,
   },*/
 ];
 
@@ -125,64 +137,174 @@ const PLUGINS = [
 ];
 
 async function runCodegen() {
-  console.log("\nGenerate types for general modules:");
-  const typesPath = `${core.apiPath}/types.ts`;
-  await generate(
-    {
-      schema: [core.schemaPath, core.clientDirectivesPath],
-      silent: true,
-      documents: [
-        addExtension(core.apiPath),
-        // exclude independent modules from general modules
-        ...independentModules.map((module) => `!${addExtension(module.apiPath)}`),
-        // exclude client-only directive declarations — they are not operations
-        `!${core.clientDirectivesPath}`,
-      ],
-      generates: {
-        [typesPath]: {
-          plugins: PLUGINS,
-          config: CONFIG,
+  if (!backendUrl) {
+    console.error(`${RED}✖ APP_BACKEND_URL is not set, there is no schema to generate types from.${RESET}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(`\nGenerating GraphQL types from "${backendUrl}":`);
+
+  const coreOutcome = await generateTypes({
+    name: "Core",
+    schemaUrl: core.schemaPath,
+    schema: [core.schemaPath, core.clientDirectivesPath],
+    documents: [
+      addExtension(core.apiPath),
+      // exclude independent modules from general modules
+      ...independentModules.map((module) => `!${addExtension(module.apiPath)}`),
+      // exclude client-only directive declarations — they are not operations
+      `!${core.clientDirectivesPath}`,
+    ],
+    typesPath: `${core.apiPath}/types.ts`,
+  });
+
+  if (coreOutcome.status !== "generated") {
+    // Every module request would fail the same way without the core schema, so there is nothing to continue with.
+    reportAbortedCore(coreOutcome);
+    process.exitCode = 1;
+    return;
+  }
+
+  reportOutcome(coreOutcome);
+
+  // Reported as each module settles, so a slow environment keeps showing progress. The array itself
+  // stays in declaration order, which is what the summary reads.
+  const moduleOutcomes = await Promise.all(
+    independentModules.map((module) =>
+      generateTypes({
+        name: module.name,
+        schemaUrl: module.schemaPath,
+        schema: module.schemaPath,
+        documents: [
+          addExtension(module.apiPath),
+          // Include specific required fragments for validation
+          ...(module.requiredCommonFragments ?? []),
+        ],
+        typesPath: `${module.apiPath}/types.ts`,
+      }).then(reportOutcome),
+    ),
+  );
+
+  printSummary([coreOutcome, ...moduleOutcomes]);
+
+  // Skipped modules are a normal state of a partially installed environment and keep the run green,
+  // a module that broke while its schema was reachable does not.
+  if (moduleOutcomes.some(({ status }) => status === "failed")) {
+    process.exitCode = 1;
+  }
+}
+
+async function generateTypes({
+  name,
+  schemaUrl,
+  schema,
+  documents,
+  typesPath,
+}: {
+  name: string;
+  /** the endpoint to check for presence, `schema` may additionally hold local files */
+  schemaUrl: string;
+  schema: string | string[];
+  documents: string[];
+  typesPath: string;
+}): Promise<OutcomeType> {
+  if (await isSchemaEndpointAbsent(schemaUrl)) {
+    // The bare fact, so that both a skipped module and an aborted core can phrase it their own way.
+    return { name, typesPath, status: "skipped", reason: `"${schemaUrl}" answered 404` };
+  }
+
+  try {
+    await generate(
+      {
+        schema,
+        silent: true,
+        documents,
+        generates: {
+          [typesPath]: {
+            plugins: PLUGINS,
+            config: CONFIG,
+          },
         },
       },
-    },
-    true,
-  );
-  console.log(`Types for The Core have been generated in "${typesPath}\n`);
+      true,
+    );
 
-  await Promise.allSettled(
-    independentModules.map(async (module) => {
-      const moduleTypesPath = `${module.apiPath}/types.ts`;
-      try {
-        await generate(
-          {
-            schema: module.schemaPath,
-            silent: true,
-            documents: [
-              addExtension(module.apiPath),
-              // Include specific required fragments for validation
-              ...(module.requiredCommonFragments || []),
-            ],
-            generates: {
-              [moduleTypesPath]: {
-                plugins: PLUGINS,
-                config: CONFIG,
-              },
-            },
-          },
-          true,
-        );
-        console.log(`Types for "${module.name}" module have been generated in "${moduleTypesPath}"\n`);
-      } catch (err) {
-        console.error(`Error during types generation for "${module.name} module"\n`, err);
-      }
-    }),
+    return { name, typesPath, status: "generated" };
+  } catch (err) {
+    // The endpoint answered the probe, so whatever went wrong here is a real problem.
+    return { name, typesPath, status: "failed", error: err };
+  }
+}
+
+/** Returns the outcome so it can be reported inline while the results are being collected. */
+function reportOutcome(outcome: OutcomeType): OutcomeType {
+  switch (outcome.status) {
+    case "generated":
+      reportSuccess(outcome);
+      break;
+    case "skipped":
+      reportSkip(outcome);
+      break;
+    case "failed":
+      reportFailure(outcome);
+      break;
+  }
+
+  return outcome;
+}
+
+function reportSuccess({ name, typesPath }: OutcomeType): void {
+  console.log(`${GREEN}✔${RESET} ${BOLD}${name}${RESET}: types generated in "${typesPath}"`);
+}
+
+function reportSkip({ name, typesPath, reason }: OutcomeType): void {
+  const consequence = existsSync(typesPath)
+    ? `keeping the committed "${typesPath}"`
+    : `"${typesPath}" is missing, imports from this module will not type-check`;
+
+  console.warn(
+    `${YELLOW}⚠${RESET} ${BOLD}${name}${RESET}: not installed on The Platform, module skipped — ${consequence}\n  ${reason}`,
   );
+}
+
+function reportFailure({ name, error }: OutcomeType): void {
+  console.error(`${RED}✖${RESET} ${BOLD}${name}${RESET}: types generation failed\n  ${describeErrorDetails(error)}`);
+}
+
+function reportAbortedCore(outcome: OutcomeType): void {
+  if (outcome.status === "skipped") {
+    // Not a module: an absent core endpoint means the URL or the backend itself is wrong.
+    console.error(
+      `${RED}✖${RESET} ${BOLD}Core${RESET}: no GraphQL schema at "${core.schemaPath}"\n  ${outcome.reason}`,
+    );
+  } else {
+    reportFailure(outcome);
+  }
+
+  console.error(
+    `${RED}The core schema is required, aborting. Check APP_BACKEND_URL and that the backend runs.${RESET}`,
+  );
+}
+
+function printSummary(outcomes: OutcomeType[]): void {
+  const { generated, skipped, failed } = groupByStatus(outcomes);
+  // A rule above the heading instead of a boxed frame: module lists are long and would break side borders.
+  const names = (group: OutcomeType[]) => group.map(({ name }) => name).join(", ");
+
+  console.log(`\n${"━".repeat(SUMMARY_WIDTH)}\n${BOLD}GraphQL types generation summary${RESET}`);
+  console.log(`  ${GREEN}✔ generated (${generated.length})${RESET}: ${names(generated)}`);
+
+  if (skipped.length) {
+    console.log(`  ${YELLOW}⚠ skipped, schema not available (${skipped.length})${RESET}: ${names(skipped)}`);
+  }
+
+  if (failed.length) {
+    console.log(`  ${RED}✖ failed (${failed.length})${RESET}: ${names(failed)}`);
+  }
 }
 
 runCodegen().catch((err) => {
   console.error(err);
+  process.exitCode = 1;
 });
-
-function addExtension(path: string): string {
-  return `${path}/**/*.(graphql|gql)`;
-}

--- a/scripts/graphql-codegen/utils.test.ts
+++ b/scripts/graphql-codegen/utils.test.ts
@@ -166,7 +166,6 @@ describe("describeErrorDetails", () => {
   });
 
   it("does not repeat the sources inside the message codegen joins them into", () => {
-    // How @graphql-codegen/cli actually builds it: wrapper message = nested messages joined.
     const error = new AggregateError(
       [new Error("cannot load schema A"), new Error("cannot load schema B")],
       "cannot load schema A\n\ncannot load schema B",
@@ -203,6 +202,12 @@ describe("describeErrorDetails", () => {
     expect(describeErrorDetails(null)).toBe("unknown error");
     expect(describeErrorDetails("plain rejection")).toBe("plain rejection");
     expect(describeErrorDetails(404)).toBe("404");
+    expect(describeErrorDetails(false)).toBe("false");
+    expect(describeErrorDetails(Symbol("nope"))).toBe("Symbol(nope)");
+  });
+
+  it("names a rejection that cannot be serialized at all", () => {
+    expect(describeErrorDetails(() => "thrown function")).toBe("[object Function]");
   });
 
   it("serializes an object rejection instead of reporting [object Object]", () => {

--- a/scripts/graphql-codegen/utils.test.ts
+++ b/scripts/graphql-codegen/utils.test.ts
@@ -175,9 +175,29 @@ describe("describeErrorDetails", () => {
     expect(details.endsWith("…")).toBe(true);
   });
 
-  it("falls back to the stringified value when there is no message", () => {
+  it("falls back to the value itself when there is no message", () => {
     expect(describeErrorDetails(undefined)).toBe("unknown error");
+    expect(describeErrorDetails(null)).toBe("unknown error");
     expect(describeErrorDetails("plain rejection")).toBe("plain rejection");
+    expect(describeErrorDetails(404)).toBe("404");
+  });
+
+  it("serializes an object rejection instead of reporting [object Object]", () => {
+    expect(describeErrorDetails({ code: 500, endpoint: "/graphql/news" })).toBe(
+      '{"code":500,"endpoint":"/graphql/news"}',
+    );
+  });
+
+  it("names an error that carries no message", () => {
+    expect(describeErrorDetails(new Error(""))).toBe("Error");
+    expect(describeErrorDetails(new AggregateError([], ""))).toBe("AggregateError");
+  });
+
+  it("survives an object that cannot be serialized", () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+
+    expect(describeErrorDetails(circular)).toBe("unserializable error object");
   });
 });
 

--- a/scripts/graphql-codegen/utils.test.ts
+++ b/scripts/graphql-codegen/utils.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  addExtension,
+  collectErrorMessages,
+  describeErrorDetails,
+  groupByStatus,
+  isSchemaEndpointAbsent,
+  normalizeBackendUrl,
+  stripCodegenHint,
+  truncate,
+} from "./utils.js";
+import type { OutcomeType } from "./utils.js";
+
+/** Verbatim shape of what `@graphql-codegen/cli` throws when a schema endpoint answers 404. */
+const SCHEMA_LOAD_ERROR_MESSAGE = `Failed to load schema from https://example.govirto.com/graphql/sales-rep:
+No response returned
+
+GraphQL Code Generator supports:
+
+- ES Modules and CommonJS exports (export as default or named export "schema")
+- Introspection JSON File
+- URL of GraphQL endpoint
+- Multiple files with type definitions (glob expression)
+- String in config file
+
+Try to use one of above options and run codegen again.
+`;
+
+function respondWith(status: number): typeof fetch {
+  return vi.fn(() => Promise.resolve(new Response("{}", { status })));
+}
+
+function outcome(name: string, status: OutcomeType["status"]): OutcomeType {
+  return { name, typesPath: `client-app/modules/${name}/api/graphql/types.ts`, status };
+}
+
+describe("normalizeBackendUrl", () => {
+  it("keeps a url without a trailing slash as is", () => {
+    expect(normalizeBackendUrl("https://example.govirto.com")).toBe("https://example.govirto.com");
+  });
+
+  it("strips trailing slashes so the schema url does not get a double slash", () => {
+    expect(normalizeBackendUrl("https://example.govirto.com/")).toBe("https://example.govirto.com");
+    expect(normalizeBackendUrl("https://example.govirto.com///")).toBe("https://example.govirto.com");
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(normalizeBackendUrl("  https://example.govirto.com/ ")).toBe("https://example.govirto.com");
+  });
+
+  it("returns an empty string when the variable is not set", () => {
+    expect(normalizeBackendUrl(undefined)).toBe("");
+    expect(normalizeBackendUrl("")).toBe("");
+  });
+});
+
+describe("isSchemaEndpointAbsent", () => {
+  it("treats 404 as the module not being installed", async () => {
+    await expect(
+      isSchemaEndpointAbsent("https://example.govirto.com/graphql/sales-rep", respondWith(404)),
+    ).resolves.toBe(true);
+  });
+
+  it("treats an answering endpoint as installed", async () => {
+    await expect(isSchemaEndpointAbsent("https://example.govirto.com/graphql/news", respondWith(200))).resolves.toBe(
+      false,
+    );
+  });
+
+  it("does not mistake a broken or protected endpoint for an uninstalled module", async () => {
+    await expect(isSchemaEndpointAbsent("https://example.govirto.com/graphql", respondWith(500))).resolves.toBe(false);
+    await expect(isSchemaEndpointAbsent("https://example.govirto.com/graphql", respondWith(401))).resolves.toBe(false);
+    await expect(isSchemaEndpointAbsent("https://example.govirto.com/graphql", respondWith(302))).resolves.toBe(false);
+  });
+
+  it("leaves the verdict to codegen when the probe itself cannot connect", async () => {
+    const failing = vi.fn(() => Promise.reject(new Error("getaddrinfo ENOTFOUND"))) as unknown as typeof fetch;
+
+    await expect(isSchemaEndpointAbsent("https://no-such-host.invalid/graphql", failing)).resolves.toBe(false);
+  });
+
+  it("probes with a minimal GraphQL query so an endpoint that rejects GET is not read as absent", async () => {
+    const fetchImpl = respondWith(200);
+
+    await isSchemaEndpointAbsent("https://example.govirto.com/graphql/news", fetchImpl);
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://example.govirto.com/graphql/news",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ query: "{__typename}" }),
+      }),
+    );
+  });
+});
+
+describe("collectErrorMessages", () => {
+  it("returns the message of a plain error", () => {
+    expect(collectErrorMessages(new Error("boom"))).toEqual(["boom"]);
+  });
+
+  it("flattens the per-source errors of an aggregate error", () => {
+    const error = new AggregateError([new Error("first"), new Error("second")], "aggregate");
+
+    expect(collectErrorMessages(error)).toEqual(["aggregate", "first", "second"]);
+  });
+
+  it("flattens nested aggregate errors", () => {
+    const error = new AggregateError([new AggregateError([new Error("leaf")], "inner")], "outer");
+
+    expect(collectErrorMessages(error)).toEqual(["outer", "inner", "leaf"]);
+  });
+
+  it("ignores values that are not errors", () => {
+    expect(collectErrorMessages(undefined)).toEqual([]);
+    expect(collectErrorMessages(null)).toEqual([]);
+    expect(collectErrorMessages("just a string")).toEqual([]);
+    expect(collectErrorMessages(new Error(""))).toEqual([]);
+  });
+});
+
+describe("stripCodegenHint", () => {
+  it("drops the cheat sheet and collapses the message into one line", () => {
+    expect(stripCodegenHint(SCHEMA_LOAD_ERROR_MESSAGE)).toBe(
+      "Failed to load schema from https://example.govirto.com/graphql/sales-rep: No response returned",
+    );
+  });
+
+  it("keeps a message that has no cheat sheet", () => {
+    expect(stripCodegenHint("Unknown type Foo")).toBe("Unknown type Foo");
+  });
+});
+
+describe("truncate", () => {
+  it("leaves text within the limit untouched", () => {
+    expect(truncate("short", 10)).toBe("short");
+  });
+
+  it("marks text it had to cut", () => {
+    expect(truncate("0123456789", 4)).toBe("0123…");
+  });
+});
+
+describe("describeErrorDetails", () => {
+  it("reports every distinct message of an aggregate error", () => {
+    const error = new AggregateError(
+      [new Error("first source failed"), new Error("second source failed")],
+      "aggregate",
+    );
+
+    expect(describeErrorDetails(error)).toBe("aggregate\n  first source failed\n  second source failed");
+  });
+
+  it("does not repeat the message an aggregate error copied from its only source", () => {
+    expect(describeErrorDetails(new AggregateError([new Error("boom")], "boom"))).toBe("boom");
+  });
+
+  it("keeps a document validation error listing several fields readable", () => {
+    const validation = new Error(
+      'GraphQL Document Validation failed with 2 errors;\nError 0: Cannot query field "newsArticle" on type "Query".\nError 1: Cannot query field "newsArticles" on type "Query".',
+    );
+
+    expect(describeErrorDetails(validation)).toBe(
+      'GraphQL Document Validation failed with 2 errors; Error 0: Cannot query field "newsArticle" on type "Query". Error 1: Cannot query field "newsArticles" on type "Query".',
+    );
+  });
+
+  it("truncates an endpoint that quoted its whole non-schema response body", () => {
+    const html = `<!DOCTYPE html>\n<html>${"<div>filler</div>".repeat(500)}</html>`;
+    const details = describeErrorDetails(new Error(`Unexpected response: "${html}"`));
+
+    expect(details.length).toBeLessThanOrEqual(2001);
+    expect(details).toMatch(/^Unexpected response: "<!DOCTYPE html>/);
+    expect(details.endsWith("…")).toBe(true);
+  });
+
+  it("falls back to the stringified value when there is no message", () => {
+    expect(describeErrorDetails(undefined)).toBe("unknown error");
+    expect(describeErrorDetails("plain rejection")).toBe("plain rejection");
+  });
+});
+
+describe("groupByStatus", () => {
+  it("splits outcomes per status and preserves their order", () => {
+    const outcomes = [
+      outcome("Core", "generated"),
+      outcome("SalesRep", "skipped"),
+      outcome("Quotes", "generated"),
+      outcome("News", "failed"),
+    ];
+
+    expect(groupByStatus(outcomes)).toEqual({
+      generated: [outcomes[0], outcomes[2]],
+      skipped: [outcomes[1]],
+      failed: [outcomes[3]],
+    });
+  });
+
+  it("returns empty groups for an empty run", () => {
+    expect(groupByStatus([])).toEqual({ generated: [], skipped: [], failed: [] });
+  });
+});
+
+describe("addExtension", () => {
+  it("builds a recursive glob for both document extensions", () => {
+    expect(addExtension("client-app/modules/news/api/graphql")).toBe(
+      "client-app/modules/news/api/graphql/**/*.(graphql|gql)",
+    );
+  });
+});

--- a/scripts/graphql-codegen/utils.test.ts
+++ b/scripts/graphql-codegen/utils.test.ts
@@ -100,16 +100,29 @@ describe("collectErrorMessages", () => {
     expect(collectErrorMessages(new Error("boom"))).toEqual(["boom"]);
   });
 
-  it("flattens the per-source errors of an aggregate error", () => {
-    const error = new AggregateError([new Error("first"), new Error("second")], "aggregate");
+  it("reports the per-source errors of an aggregate, not the wrapper's copy of them", () => {
+    // Codegen builds the wrapper message by joining the nested ones, so the wrapper adds nothing.
+    const error = new AggregateError([new Error("first"), new Error("second")], "first\n\nsecond");
 
-    expect(collectErrorMessages(error)).toEqual(["aggregate", "first", "second"]);
+    expect(collectErrorMessages(error)).toEqual(["first", "second"]);
   });
 
-  it("flattens nested aggregate errors", () => {
+  it("digs down to the leaves of nested aggregates", () => {
     const error = new AggregateError([new AggregateError([new Error("leaf")], "inner")], "outer");
 
-    expect(collectErrorMessages(error)).toEqual(["outer", "inner", "leaf"]);
+    expect(collectErrorMessages(error)).toEqual(["leaf"]);
+  });
+
+  it("keeps the wrapper message when its sources have nothing to say", () => {
+    expect(collectErrorMessages(new AggregateError([], "only the wrapper knows"))).toEqual(["only the wrapper knows"]);
+    expect(collectErrorMessages(new AggregateError([new Error("")], "wrapper"))).toEqual(["wrapper"]);
+  });
+
+  it("survives a self-referential error chain instead of overflowing the stack", () => {
+    const error: Error & { errors?: unknown[] } = new Error("recursive");
+    error.errors = [error];
+
+    expect(collectErrorMessages(error)).toEqual(["recursive"]);
   });
 
   it("ignores values that are not errors", () => {
@@ -143,13 +156,23 @@ describe("truncate", () => {
 });
 
 describe("describeErrorDetails", () => {
-  it("reports every distinct message of an aggregate error", () => {
+  it("reports one line per failing schema source", () => {
     const error = new AggregateError(
       [new Error("first source failed"), new Error("second source failed")],
       "aggregate",
     );
 
-    expect(describeErrorDetails(error)).toBe("aggregate\n  first source failed\n  second source failed");
+    expect(describeErrorDetails(error)).toBe("first source failed\n  second source failed");
+  });
+
+  it("does not repeat the sources inside the message codegen joins them into", () => {
+    // How @graphql-codegen/cli actually builds it: wrapper message = nested messages joined.
+    const error = new AggregateError(
+      [new Error("cannot load schema A"), new Error("cannot load schema B")],
+      "cannot load schema A\n\ncannot load schema B",
+    );
+
+    expect(describeErrorDetails(error)).toBe("cannot load schema A\n  cannot load schema B");
   });
 
   it("does not repeat the message an aggregate error copied from its only source", () => {

--- a/scripts/graphql-codegen/utils.ts
+++ b/scripts/graphql-codegen/utils.ts
@@ -99,10 +99,35 @@ export function describeErrorDetails(error: unknown): string {
   const messages = [...new Set(collectErrorMessages(error).map(stripCodegenHint))];
 
   if (!messages.length) {
-    return String(error ?? "unknown error");
+    return describeValue(error);
   }
 
   return messages.map((message) => truncate(message, MAX_DETAILS_LENGTH)).join("\n  ");
+}
+
+/**
+ * Last resort for a rejection that carries no error message. Stringifying an object would only
+ * report "[object Object]", so serialize it instead — that is the only content it has to offer.
+ */
+function describeValue(value: unknown): string {
+  if (value === null || value === undefined) {
+    return "unknown error";
+  }
+
+  if (value instanceof Error) {
+    return value.name;
+  }
+
+  if (typeof value !== "object") {
+    return String(value);
+  }
+
+  try {
+    return truncate(JSON.stringify(value), MAX_DETAILS_LENGTH);
+  } catch {
+    // Circular or otherwise unserializable — there is nothing more to say about it.
+    return "unserializable error object";
+  }
 }
 
 export function groupByStatus(outcomes: OutcomeType[]): Record<OutcomeStatusType, OutcomeType[]> {

--- a/scripts/graphql-codegen/utils.ts
+++ b/scripts/graphql-codegen/utils.ts
@@ -17,13 +17,13 @@ export type OutcomeType = {
   name: string;
   typesPath: string;
   status: OutcomeStatusType;
-  /** short human-readable explanation, set for `skipped` */
+  /** short explanation, set for `skipped` */
   reason?: string;
   /** the original error, set for `failed` */
   error?: unknown;
 };
 
-/** Codegen appends a long cheat sheet of the supported schema formats to schema loading failures. */
+/** Codegen appends a cheat sheet of the supported schema formats to every schema loading failure. */
 const CODEGEN_HINT_HEADING = "GraphQL Code Generator supports:";
 
 /** Enough of a failure to act on without pasting a whole response body into the terminal. */
@@ -31,10 +31,10 @@ const MAX_DETAILS_LENGTH = 2000;
 
 const PROBE_TIMEOUT_MS = 15_000;
 
-/** The cheapest valid query every GraphQL endpoint answers, used to tell 404 from a working module. */
+/** The cheapest query every GraphQL endpoint answers, so an endpoint that rejects GET still counts. */
 const PROBE_BODY = JSON.stringify({ query: "{__typename}" });
 
-/** `https://host/` and `https://host` must produce the same schema URL, `//graphql` answers 404. */
+/** A trailing slash would produce `//graphql`, which answers 404. */
 export function normalizeBackendUrl(url: string | undefined): string {
   let normalized = (url ?? "").trim();
 
@@ -47,10 +47,9 @@ export function normalizeBackendUrl(url: string | undefined): string {
 }
 
 /**
- * The Platform answers 404 on the scoped GraphQL endpoint of a module it does not have installed,
- * and that is the only response proving the module is absent. Every other outcome — 401, 500, an
- * HTML page, a connection error — means generation must be attempted and its error reported, so that
- * a broken or misconfigured endpoint is never silently mistaken for an uninstalled module.
+ * A 404 is the only answer The Platform gives for a module it does not have. Anything else — 401,
+ * 500, an HTML page, a connection error — means generation must be attempted and its error reported,
+ * so that a broken or misconfigured endpoint is never mistaken for an uninstalled module.
  */
 export async function isSchemaEndpointAbsent(url: string, fetchImpl: typeof fetch = fetch): Promise<boolean> {
   try {
@@ -63,17 +62,14 @@ export async function isSchemaEndpointAbsent(url: string, fetchImpl: typeof fetc
 
     return response.status === 404;
   } catch {
-    // Let codegen make the call: it reaches the endpoint on its own terms (proxies, TLS overrides).
+    // Codegen reaches the endpoint on its own terms (proxies, TLS overrides), so let it decide.
     return false;
   }
 }
 
 /**
- * Codegen wraps loader failures into an `AggregateError` holding one error per schema source, and
- * sets the wrapper's own message to those nested messages joined together. The leaves therefore
- * carry everything, and reporting the wrapper as well would print the same text twice.
- *
- * `seen` guards against a self-referential `errors` chain, which would otherwise recurse forever.
+ * Codegen sets an `AggregateError`'s own message to its nested messages joined together, so the
+ * leaves carry everything. `seen` guards against a self-referential `errors` chain.
  */
 export function collectErrorMessages(error: unknown, seen: Set<unknown> = new Set()): string[] {
   if (typeof error === "object" && error !== null) {
@@ -94,7 +90,7 @@ export function collectErrorMessages(error: unknown, seen: Set<unknown> = new Se
   return error instanceof Error && error.message ? [error.message] : [];
 }
 
-/** Turns a multi-line codegen message into one line, without the cheat sheet nobody reads. */
+/** Turns a multi-line codegen message into one line, without the cheat sheet. */
 export function stripCodegenHint(message: string): string {
   // eslint-disable-next-line sonarjs/null-dereference -- false positive: message is a typed string parameter
   const hintAt = message.indexOf(CODEGEN_HINT_HEADING);
@@ -107,9 +103,7 @@ export function truncate(text: string, maxLength: number): string {
   return text.length > maxLength ? `${text.slice(0, maxLength)}…` : text;
 }
 
-/** Everything known about a failure, readable enough to act on. */
 export function describeErrorDetails(error: unknown): string {
-  // Two schema sources can fail with the same message, and saying it twice helps nobody.
   const messages = [...new Set(collectErrorMessages(error).map(stripCodegenHint))];
 
   if (!messages.length) {
@@ -119,10 +113,7 @@ export function describeErrorDetails(error: unknown): string {
   return messages.map((message) => truncate(message, MAX_DETAILS_LENGTH)).join("\n  ");
 }
 
-/**
- * Last resort for a rejection that carries no error message. Stringifying an object would only
- * report "[object Object]", so serialize it instead — that is the only content it has to offer.
- */
+/** Last resort for a rejection with no error message: an object's content is all it has to offer. */
 function describeValue(value: unknown): string {
   if (value === null || value === undefined) {
     return "unknown error";
@@ -132,14 +123,24 @@ function describeValue(value: unknown): string {
     return value.name;
   }
 
-  if (typeof value !== "object") {
-    return String(value);
+  if (typeof value === "string") {
+    return truncate(value, MAX_DETAILS_LENGTH);
+  }
+
+  if (typeof value === "number" || typeof value === "bigint" || typeof value === "boolean") {
+    return value.toString();
+  }
+
+  if (typeof value === "symbol") {
+    return value.toString();
   }
 
   try {
-    return truncate(JSON.stringify(value), MAX_DETAILS_LENGTH);
+    // JSON.stringify answers undefined for a function.
+    const serialized: string | undefined = JSON.stringify(value);
+
+    return truncate(serialized ?? Object.prototype.toString.call(value), MAX_DETAILS_LENGTH);
   } catch {
-    // Circular or otherwise unserializable — there is nothing more to say about it.
     return "unserializable error object";
   }
 }

--- a/scripts/graphql-codegen/utils.ts
+++ b/scripts/graphql-codegen/utils.ts
@@ -68,16 +68,30 @@ export async function isSchemaEndpointAbsent(url: string, fetchImpl: typeof fetc
   }
 }
 
-/** Codegen wraps loader failures into an `AggregateError` holding one error per schema source. */
-export function collectErrorMessages(error: unknown): string[] {
-  const messages = error instanceof Error && error.message ? [error.message] : [];
-  const nested = (error as { errors?: unknown } | null | undefined)?.errors;
+/**
+ * Codegen wraps loader failures into an `AggregateError` holding one error per schema source, and
+ * sets the wrapper's own message to those nested messages joined together. The leaves therefore
+ * carry everything, and reporting the wrapper as well would print the same text twice.
+ *
+ * `seen` guards against a self-referential `errors` chain, which would otherwise recurse forever.
+ */
+export function collectErrorMessages(error: unknown, seen: Set<unknown> = new Set()): string[] {
+  if (typeof error === "object" && error !== null) {
+    if (seen.has(error)) {
+      return [];
+    }
 
-  if (Array.isArray(nested)) {
-    messages.push(...nested.flatMap((item) => collectErrorMessages(item)));
+    seen.add(error);
   }
 
-  return messages;
+  const nested = (error as { errors?: unknown } | null | undefined)?.errors;
+  const nestedMessages = Array.isArray(nested) ? nested.flatMap((item) => collectErrorMessages(item, seen)) : [];
+
+  if (nestedMessages.length) {
+    return nestedMessages;
+  }
+
+  return error instanceof Error && error.message ? [error.message] : [];
 }
 
 /** Turns a multi-line codegen message into one line, without the cheat sheet nobody reads. */
@@ -95,7 +109,7 @@ export function truncate(text: string, maxLength: number): string {
 
 /** Everything known about a failure, readable enough to act on. */
 export function describeErrorDetails(error: unknown): string {
-  // An aggregate error repeats its only nested message as its own, printing it twice helps nobody.
+  // Two schema sources can fail with the same message, and saying it twice helps nobody.
   const messages = [...new Set(collectErrorMessages(error).map(stripCodegenHint))];
 
   if (!messages.length) {

--- a/scripts/graphql-codegen/utils.ts
+++ b/scripts/graphql-codegen/utils.ts
@@ -1,0 +1,118 @@
+export type ModuleType = {
+  name: string;
+  apiPath: string;
+  schemaPath: string;
+  requiredCommonFragments?: string[]; // Specific core fragment files that module depends on
+};
+
+export type OutcomeStatusType =
+  /** `types.ts` has been written */
+  | "generated"
+  /** the module is not installed on The Platform, so it exposes no schema endpoint */
+  | "skipped"
+  /** the schema endpoint answered, but generation broke */
+  | "failed";
+
+export type OutcomeType = {
+  name: string;
+  typesPath: string;
+  status: OutcomeStatusType;
+  /** short human-readable explanation, set for `skipped` */
+  reason?: string;
+  /** the original error, set for `failed` */
+  error?: unknown;
+};
+
+/** Codegen appends a long cheat sheet of the supported schema formats to schema loading failures. */
+const CODEGEN_HINT_HEADING = "GraphQL Code Generator supports:";
+
+/** Enough of a failure to act on without pasting a whole response body into the terminal. */
+const MAX_DETAILS_LENGTH = 2000;
+
+const PROBE_TIMEOUT_MS = 15_000;
+
+/** The cheapest valid query every GraphQL endpoint answers, used to tell 404 from a working module. */
+const PROBE_BODY = JSON.stringify({ query: "{__typename}" });
+
+/** `https://host/` and `https://host` must produce the same schema URL, `//graphql` answers 404. */
+export function normalizeBackendUrl(url: string | undefined): string {
+  let normalized = (url ?? "").trim();
+
+  // eslint-disable-next-line sonarjs/null-dereference -- false positive: trim() always returns a string
+  while (normalized.endsWith("/")) {
+    normalized = normalized.slice(0, -1);
+  }
+
+  return normalized;
+}
+
+/**
+ * The Platform answers 404 on the scoped GraphQL endpoint of a module it does not have installed,
+ * and that is the only response proving the module is absent. Every other outcome — 401, 500, an
+ * HTML page, a connection error — means generation must be attempted and its error reported, so that
+ * a broken or misconfigured endpoint is never silently mistaken for an uninstalled module.
+ */
+export async function isSchemaEndpointAbsent(url: string, fetchImpl: typeof fetch = fetch): Promise<boolean> {
+  try {
+    const response = await fetchImpl(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: PROBE_BODY,
+      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+    });
+
+    return response.status === 404;
+  } catch {
+    // Let codegen make the call: it reaches the endpoint on its own terms (proxies, TLS overrides).
+    return false;
+  }
+}
+
+/** Codegen wraps loader failures into an `AggregateError` holding one error per schema source. */
+export function collectErrorMessages(error: unknown): string[] {
+  const messages = error instanceof Error && error.message ? [error.message] : [];
+  const nested = (error as { errors?: unknown } | null | undefined)?.errors;
+
+  if (Array.isArray(nested)) {
+    messages.push(...nested.flatMap((item) => collectErrorMessages(item)));
+  }
+
+  return messages;
+}
+
+/** Turns a multi-line codegen message into one line, without the cheat sheet nobody reads. */
+export function stripCodegenHint(message: string): string {
+  // eslint-disable-next-line sonarjs/null-dereference -- false positive: message is a typed string parameter
+  const hintAt = message.indexOf(CODEGEN_HINT_HEADING);
+
+  return (hintAt === -1 ? message : message.slice(0, hintAt)).replace(/\s+/g, " ").trim();
+}
+
+export function truncate(text: string, maxLength: number): string {
+  // eslint-disable-next-line sonarjs/null-dereference -- false positive: text is a typed string parameter
+  return text.length > maxLength ? `${text.slice(0, maxLength)}…` : text;
+}
+
+/** Everything known about a failure, readable enough to act on. */
+export function describeErrorDetails(error: unknown): string {
+  // An aggregate error repeats its only nested message as its own, printing it twice helps nobody.
+  const messages = [...new Set(collectErrorMessages(error).map(stripCodegenHint))];
+
+  if (!messages.length) {
+    return String(error ?? "unknown error");
+  }
+
+  return messages.map((message) => truncate(message, MAX_DETAILS_LENGTH)).join("\n  ");
+}
+
+export function groupByStatus(outcomes: OutcomeType[]): Record<OutcomeStatusType, OutcomeType[]> {
+  return {
+    generated: outcomes.filter(({ status }) => status === "generated"),
+    skipped: outcomes.filter(({ status }) => status === "skipped"),
+    failed: outcomes.filter(({ status }) => status === "failed"),
+  };
+}
+
+export function addExtension(path: string): string {
+  return `${path}/**/*.(graphql|gql)`;
+}


### PR DESCRIPTION
## Description

**Before**
<img width="664" height="920" alt="image" src="https://github.com/user-attachments/assets/e5bbf83a-7484-43ab-af43-04055bc40157" />

**After**
<img width="1240" height="302" alt="image" src="https://github.com/user-attachments/assets/c38d9c60-cfe3-49fa-a7b9-e00a2a192fb7" />

---

**TL;DR** — codegen against an env that misses a module now prints **one clear line** instead of a 15-line error dump. And the run can finally **fail when something is actually broken**.

Only `scripts/graphql-codegen/*` + two READMEs. No app code.

### The two problems

1. 🙈 **Unreadable** — one missing module = 15 lines of `Failed to load schema … GraphQL Code Generator supports: ES Modules and CommonJS exports …`. So people commented modules out of the list instead (`PurchaseRequests` still is).
2. 🟢 **Always green** — nothing could fail the run. A broken module, an absent module and a **dead backend** all exited `0`.

### How it works now

```
yarn generate:graphql-types
   │
   ├─ APP_BACKEND_URL empty? ──────────────► ✖ exit 1
   │  (trailing "/" stripped first)
   │
   ▼
CORE  ── probe POST {__typename} → /graphql
   │
   ├─ 404 / unreachable / codegen error ───► ✖ abort, exit 1
   │                                          (modules never attempted)
   ▼
✔ core/api/graphql/types.ts written
   │
   ▼
7 MODULES, all at once ── each one independently:

        probe its /graphql/<module>
                    │
        ┌───────────┴────────────┐
      404                   anything else
        │                        │
  types.ts committed?       run codegen
        │        │               │
      yes        no         ok ──┴── error
        │        │           │        │
     ⚠ SKIP   ✖ FAIL      ✔ GEN    ✖ FAIL
    reuse it   exit 1                exit 1
     exit 0
```

- **404** = not installed → skip, reuse the committed `types.ts`, stay green.
- **404 + no `types.ts`** → nothing to reuse → **fail**.
- **Endpoint answers but breaks** (`401`/`500`/HTML/stale `.graphql` queries) → **fail**.
- **Core missing** → abort at once, instead of 7 identical errors.

**Why probe at all:** codegen's error text is *identical* for `404`, `500`, an HTML page and a DNS failure. Without the probe you cannot tell "not installed" from "broken" — that is the whole trick.

### Before → after

**Before:**

```
Error during types generation for "SalesRep module"
 AggregateError: Failed to load schema from https://…/graphql/sales-rep:
No response returned

GraphQL Code Generator supports:

- ES Modules and CommonJS exports (export as default or named export "schema")
- Introspection JSON File
- URL of GraphQL endpoint
… 8 more lines …
```

**After:**

```
⚠ SalesRep: no schema at its endpoint, module skipped as not installed — keeping the committed "…/types.ts"
  "https://…/graphql/sales-rep" answered 404

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
GraphQL types generation summary
  ✔ generated (7): Core, CustomerReviews, PushMessages, Quotes, BackInStock, News, Loyalty
  ⚠ skipped, schema not available (1): SalesRep
```

### What's actually new

Everything below **used to exit `0`** — silently. The rest of this PR is output.

| Situation | Now |
|---|---|
| `.graphql` queries ask for fields the schema lacks | ✖ fails, exit `1` |
| Endpoint answers `401` / `500` / an HTML page | ✖ fails, exit `1` |
| `404` **and** no committed `types.ts` to reuse | ✖ fails, exit `1` |
| Backend unreachable / no core schema | ✖ aborts, one message, exit `1` |

### Bonus fixes

- 🔧 `APP_BACKEND_URL` ending in `/` made `…//graphql` → `404` → looked like a dead backend. Now normalized.
- 🔧 An endpoint returning HTML used to quote **its whole page** into the error. Now capped.

### Verified (not just reasoned)

Ran against `virtostart-demo-admin`, which really has no `sales-rep` module:

- ✅ absent module → 7 generated, 1 skipped, exit **0**
- ✅ `News` pointed at a foreign live schema → `✖ News` + 4 `Cannot query field …` errors, other 6 still generated, exit **1**
- ✅ core endpoint `404` → aborts with `✖ Core: no GraphQL schema at "…"`, exit **1**
- ✅ 32 unit tests, `validate:types`, `eslint`, `prettier --check` all pass

### Docs

- 📄 Root `README.md` → "Types generation": the skip rules, and that a `404` is evidence not proof.
- 📄 `client-app/modules/README.md`: module authors are told to **leave the entry in `independentModules`** when the backend module is absent, instead of commenting it out.

### One trade-off to know

A skipped module keeps a `types.ts` **this run never validated** — same as before, and intentional for partial envs. A `404` is strong evidence, not proof: a *renamed* scoped endpoint answers the same way and is skipped too, which is why the endpoint URL is printed. Fail-closed on any `404` was considered and rejected: it would break the whole point on partially installed environments. A wrong `APP_BACKEND_URL` is already covered — the **core** endpoint is probed too, so it aborts with exit `1` instead of skipping every module.

## References
### Jira-link:
<!-- No Jira ticket: developer-experience fix to the codegen script. -->
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.54.0-pr-2403-a07e-a07ed289.zip




