### PR TITLE
fix(VCST-5514): vc-select button layout & vc-menu-item focus

### DIFF
--- a/client-app/ui-kit/components/molecules/menu-item/vc-menu-item.vue
+++ b/client-app/ui-kit/components/molecules/menu-item/vc-menu-item.vue
@@ -256,7 +256,7 @@ onMounted(() => {
 
         &:focus,
         &:focus-visible {
-          @apply outline-[--focus-color] -outline-offset-1 rounded;
+          @apply outline-[--focus-color] -outline-offset-2 rounded-[inherit];
         }
 
         &#{$active} {

--- a/client-app/ui-kit/components/molecules/select/vc-select.vue
+++ b/client-app/ui-kit/components/molecules/select/vc-select.vue
@@ -106,15 +106,17 @@
               @click.stop="clear"
             />
 
-            <button
+            <VcButton
               :aria-label="$t('ui_kit.buttons.toggle_dropdown')"
+              :disabled="disabled"
+              :icon="isShown ? 'chevron-up' : 'chevron-down'"
               type="button"
+              color="neutral"
+              variant="ghost"
               tabindex="-1"
               class="vc-select__arrow"
               @click="handleArrowClick($event, toggle)"
-            >
-              <VcIcon :name="isShown ? 'chevron-up' : 'chevron-down'" size="xs" />
-            </button>
+            />
           </template>
         </VcInput>
       </template>
@@ -542,16 +544,6 @@ function handleTab(event: KeyboardEvent, index: number) {
   }
 
   &__arrow {
-    @apply flex items-center h-full pe-3 ps-1 text-neutral-900;
-
-    &:hover {
-      @apply text-neutral;
-    }
-
-    #{$disabled} & {
-      @apply text-neutral;
-    }
-
     #{$readonly} & {
       @apply hidden;
     }


### PR DESCRIPTION
## Description

## References
### Jira-link:
<!-- Put link to your task in Jira here -->
https://virtocommerce.atlassian.net/browse/VCST-5514
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.55.0-pr-2411-b7e6-b7e60370.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI-kit styling and component swap with no auth, data, or API changes.
> 
> **Overview**
> **Menu item focus** uses a slightly larger negative outline offset (`-outline-offset-2`) and `rounded-[inherit]` so the focus ring follows the item’s inherited corner radius instead of a fixed `rounded`.
> 
> **Autocomplete `VcSelect` dropdown toggle** replaces the raw chevron `<button>` with **`VcButton`** (ghost neutral, same chevron icon), including **`disabled`** wiring. Custom `vc-select__arrow` layout/hover/disabled styles are removed so the control matches the existing clear button and shared button styling; readonly still hides the arrow via SCSS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7e60370fa081a5cfaf297367003dfc04e756093. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->