### PR TITLE
fix(VCST-5518): applying an invalid coupon over a working one silently drops the working coupon

### DIFF
--- a/client-app/shared/cart/composables/useCoupon.test.ts
+++ b/client-app/shared/cart/composables/useCoupon.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useCoupon } from "./useCoupon";
+
+const validateCartCouponMock = vi.hoisted(() => vi.fn());
+const addCartCouponMock = vi.hoisted(() => vi.fn());
+const removeCartCouponMock = vi.hoisted(() => vi.fn());
+const cartMock = vi.hoisted(() => ({ value: undefined as Record<string, unknown> | undefined }));
+
+vi.mock("@/shared/cart/composables/useCart", () => ({
+  useFullCart: () => ({
+    cart: cartMock,
+    validateCartCoupon: validateCartCouponMock,
+    addCartCoupon: addCartCouponMock,
+    removeCartCoupon: removeCartCouponMock,
+  }),
+}));
+
+function setAppliedCoupon(code: string) {
+  cartMock.value = { coupons: [{ code, isAppliedSuccessfully: true }] };
+}
+
+describe("useCoupon", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cartMock.value = undefined;
+  });
+
+  describe("applyCoupon replacing an already-applied coupon", () => {
+    it("should NOT remove the working coupon when the replacement is invalid", async () => {
+      setAppliedCoupon("QA");
+      validateCartCouponMock.mockResolvedValueOnce(false);
+
+      const { applyCoupon, couponError } = useCoupon();
+      await applyCoupon("FriDAY");
+
+      expect(removeCartCouponMock).not.toHaveBeenCalled();
+      expect(addCartCouponMock).not.toHaveBeenCalled();
+      expect(couponError.value).toEqual({ code: "FriDAY", type: "invalid" });
+    });
+
+    it("should validate the new code BEFORE touching the working coupon", async () => {
+      setAppliedCoupon("QA");
+      const callOrder: string[] = [];
+      validateCartCouponMock.mockImplementationOnce(async () => {
+        callOrder.push("validate");
+        return true;
+      });
+      removeCartCouponMock.mockImplementationOnce(async () => {
+        callOrder.push("remove");
+      });
+
+      const { applyCoupon } = useCoupon();
+      await applyCoupon("FriDAY");
+
+      expect(callOrder).toEqual(["validate", "remove"]);
+    });
+
+    it("should still replace the working coupon when the new code is valid", async () => {
+      setAppliedCoupon("QA");
+      validateCartCouponMock.mockResolvedValueOnce(true);
+
+      const { applyCoupon } = useCoupon();
+      await applyCoupon("FriDAY");
+
+      expect(removeCartCouponMock).toHaveBeenCalledWith("QA");
+      expect(addCartCouponMock).toHaveBeenCalledWith("FriDAY");
+    });
+
+    it("should NOT remove/re-add when re-applying the same already-applied code", async () => {
+      setAppliedCoupon("QA");
+      validateCartCouponMock.mockResolvedValueOnce(true);
+
+      const { applyCoupon } = useCoupon();
+      await applyCoupon("QA");
+
+      expect(removeCartCouponMock).not.toHaveBeenCalled();
+      expect(addCartCouponMock).toHaveBeenCalledWith("QA");
+    });
+  });
+
+  describe("applyCoupon with no coupon currently applied", () => {
+    it("should add the coupon without attempting a remove", async () => {
+      validateCartCouponMock.mockResolvedValueOnce(true);
+
+      const { applyCoupon } = useCoupon();
+      await applyCoupon("FIXED5");
+
+      expect(removeCartCouponMock).not.toHaveBeenCalled();
+      expect(addCartCouponMock).toHaveBeenCalledWith("FIXED5");
+    });
+  });
+});

--- a/client-app/shared/cart/composables/useCoupon.ts
+++ b/client-app/shared/cart/composables/useCoupon.ts
@@ -4,8 +4,11 @@ import { useFullCart } from "@/shared/cart/composables/useCart";
 type ErrorType = "invalid" | "failed";
 type CouponErrorType = { code: string; type: ErrorType };
 
+const COUPON_ERROR_TIMEOUT = 7000;
+
 const couponError = ref<CouponErrorType>();
 const loadingCouponCode = ref<string>();
+let couponErrorTimeoutId: ReturnType<typeof setTimeout> | undefined;
 
 export function useCoupon() {
   const { cart, validateCartCoupon, addCartCoupon, removeCartCoupon } = useFullCart();
@@ -15,7 +18,15 @@ export function useCoupon() {
   );
 
   function clearError() {
+    clearTimeout(couponErrorTimeoutId);
+    couponErrorTimeoutId = undefined;
     couponError.value = undefined;
+  }
+
+  function setError(error: CouponErrorType) {
+    clearTimeout(couponErrorTimeoutId);
+    couponError.value = error;
+    couponErrorTimeoutId = setTimeout(clearError, COUPON_ERROR_TIMEOUT);
   }
 
   async function applyCoupon(code: string) {
@@ -31,7 +42,7 @@ export function useCoupon() {
 
       const isValid = await validateCartCoupon(trimmed);
       if (!isValid) {
-        couponError.value = { code: trimmed, type: "invalid" };
+        setError({ code: trimmed, type: "invalid" });
         return;
       }
 
@@ -41,7 +52,7 @@ export function useCoupon() {
 
       await addCartCoupon(trimmed);
     } catch {
-      couponError.value = { code: trimmed, type: "failed" };
+      setError({ code: trimmed, type: "failed" });
     } finally {
       loadingCouponCode.value = undefined;
     }
@@ -60,7 +71,7 @@ export function useCoupon() {
 
       await removeCartCoupon(trimmed);
     } catch {
-      couponError.value = { code: trimmed, type: "failed" };
+      setError({ code: trimmed, type: "failed" });
     } finally {
       loadingCouponCode.value = undefined;
     }

--- a/client-app/shared/cart/composables/useCoupon.ts
+++ b/client-app/shared/cart/composables/useCoupon.ts
@@ -29,14 +29,14 @@ export function useCoupon() {
     try {
       loadingCouponCode.value = trimmed;
 
-      if (appliedCouponCode.value && appliedCouponCode.value !== trimmed) {
-        await removeCartCoupon(appliedCouponCode.value);
-      }
-
       const isValid = await validateCartCoupon(trimmed);
       if (!isValid) {
         couponError.value = { code: trimmed, type: "invalid" };
         return;
+      }
+
+      if (appliedCouponCode.value && appliedCouponCode.value !== trimmed) {
+        await removeCartCoupon(appliedCouponCode.value);
       }
 
       await addCartCoupon(trimmed);


### PR DESCRIPTION
## Description

## References
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5518
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.55.0-pr-2422-04ea-04eac333.zip