### PR TITLE
feat(VCST-5591): sales rep hub statistic blocks alignment

### DIFF
--- a/client-app/modules/sales-rep/components/stat-widget.vue
+++ b/client-app/modules/sales-rep/components/stat-widget.vue
@@ -95,8 +95,11 @@ withDefaults(defineProps<IProps>(), {
     color: var(--stat-widget-accent);
   }
 
+  // Two line boxes, wrapped or not, so every figure in the row starts at the same height — a one-line
+  // caption used to pull its card's value 13px above its neighbours'. `lh` is the caption's own line
+  // box, so the reserve tracks the type scale; `flex` centers a short caption on the icon's line.
   &__label {
-    @apply text-xs font-bold uppercase tracking-wide text-neutral-500;
+    @apply flex min-h-[2lh] items-center text-xs font-bold uppercase tracking-wide text-neutral-500;
   }
 
   &__value {


### PR DESCRIPTION
## Description
Fixes vertical misalignment of the statistical metrics of the sales rep hub dashboard

**Before:**
<img width="1066" height="278" alt="image" src="https://github.com/user-attachments/assets/44ddc0ac-fe9c-4c6c-807a-ffd38f090d6b" />


**After:**
<img width="1196" height="320" alt="image" src="https://github.com/user-attachments/assets/cfdb21a6-7e89-4f71-b406-e9a185f14fac" />

## References
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5591
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.55.0-pr-2434-96ee-96ee7c3e.zip