### PR TITLE
fix(VCST-5752): settings icon

### DIFF
--- a/client-app/pages/account/list-details.vue
+++ b/client-app/pages/account/list-details.vue
@@ -53,7 +53,7 @@
             :disabled="loading || !list"
             size="sm"
             variant="outline"
-            prepend-icon="cog"
+            prepend-icon="settings"
             class="grow"
             @click="openListSettingsModal"
           >

--- a/client-app/shared/account/components/address-dropdown-menu.vue
+++ b/client-app/shared/account/components/address-dropdown-menu.vue
@@ -3,12 +3,14 @@
     <template #trigger="{ triggerProps }">
       <VcButton
         :aria-label="$t('common.labels.actions')"
-        icon="cog"
+        icon
         color="secondary"
         variant="outline"
         size="xs"
         v-bind="triggerProps"
-      />
+      >
+        <VcIcon name="cog" variant="solid" />
+      </VcButton>
     </template>
 
     <template #content>

--- a/client-app/shared/company/components/members-dropdown-menu.vue
+++ b/client-app/shared/company/components/members-dropdown-menu.vue
@@ -3,12 +3,14 @@
     <template #trigger="{ triggerProps }">
       <VcButton
         :aria-label="$t('common.labels.actions')"
-        icon="cog"
+        icon
         color="secondary"
         variant="outline"
         size="xs"
         v-bind="triggerProps"
-      />
+      >
+        <VcIcon name="cog" variant="solid" />
+      </VcButton>
     </template>
 
     <template #content>

--- a/client-app/shared/wishlists/components/wishlist-dropdown-menu.vue
+++ b/client-app/shared/wishlists/components/wishlist-dropdown-menu.vue
@@ -2,13 +2,15 @@
   <VcDropdownMenu :y-offset="4" :x-offset="0" placement="bottom-end">
     <template #trigger="{ triggerProps }">
       <VcButton
-        data-test-id="wishlist-card-menu-button"
-        icon="cog"
+        :aria-label="$t('common.labels.actions')"
+        icon
         color="secondary"
         variant="outline"
         size="xs"
         v-bind="triggerProps"
-      />
+      >
+        <VcIcon name="cog" variant="solid" />
+      </VcButton>
     </template>
 
     <template #content>

--- a/client-app/shared/wishlists/components/wishlist-dropdown-menu.vue
+++ b/client-app/shared/wishlists/components/wishlist-dropdown-menu.vue
@@ -2,6 +2,7 @@
   <VcDropdownMenu :y-offset="4" :x-offset="0" placement="bottom-end">
     <template #trigger="{ triggerProps }">
       <VcButton
+        data-test-id="wishlist-card-menu-button"
         :aria-label="$t('common.labels.actions')"
         icon
         color="secondary"


### PR DESCRIPTION
## Description
<img width="160" height="60" alt="Screenshot 2026-08-24 at 12 10 16" src="https://github.com/user-attachments/assets/2a67731b-da95-4900-9a03-316ebe15424d" />
<img width="765" height="294" alt="Screenshot 2026-08-24 at 12 10 59" src="https://github.com/user-attachments/assets/1f3c73ab-9823-4e0d-8133-a6e6cae02bcc" />
<img width="953" height="410" alt="Screenshot 2026-08-24 at 12 13 37" src="https://github.com/user-attachments/assets/566c273c-82d9-45de-be40-b2709f35e72f" />
<img width="913" height="332" alt="Screenshot 2026-08-24 at 12 14 12" src="https://github.com/user-attachments/assets/3a479c6c-b938-463c-bbd0-9742838a90a6" />

## References
### Jira-link:
<!-- Put link to your task in Jira here -->
https://virtocommerce.atlassian.net/browse/VCST-5752
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.56.0-pr-2449-63de-63ded416.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic icon and a11y markup only; no logic, data, or security changes.
> 
> **Overview**
> Updates settings/action button icons so they render the intended glyphs.
> 
> Wishlist list details now uses `prepend-icon="settings"` instead of `cog`. Address, company members, and wishlist dropdown triggers switch from `icon="cog"` on `VcButton` to an icon-only button with a slotted solid `cog` `VcIcon`. The wishlist menu trigger also gets an actions `aria-label`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63ded416f2ea22c6ca89b0a76b96a9b56042d5bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->