### PR TITLE
feat(VCST-5337): tag GA events with customer identity

### DIFF
--- a/client-app/modules/google-analytics/README.md
+++ b/client-app/modules/google-analytics/README.md
@@ -32,12 +32,14 @@ Configure the following settings in the Virto Commerce backend:
 3. Both can work independently or together
 
 The GTM implementation follows Google's best practices:
+
 - GTM script is injected in the `<head>` section
 - `dataLayer` is properly initialized before GTM loads
 
 ### Event Handling
 
 The module automatically sends ecommerce events regardless of whether you use:
+
 - **GTM Only**: Events are pushed directly to `dataLayer` for GTM to capture
 - **GA4 Only**: Events are sent via `gtag()` API
 - **Both GTM + GA4**: Events are sent via `gtag()` which pushes to `dataLayer`, allowing both systems to track
@@ -83,6 +85,55 @@ export const extendGoogleAnalyticsEvents: ExtendEventsType = ({ sendEvent, produ
     },
   })
 ```
+
+## Customer identity (custom dimensions)
+
+Every authenticated event is tagged with the customer's identity, so the **standard** GA4 events this
+module already sends — `view_item`, `search`, `view_search_results`, `add_to_cart` — can be reported for a
+single contact or organization instead of the whole store. No custom events are involved, and none are
+needed: GA4 simply has no built-in `userId` dimension, so without these properties there is no way to
+narrow any report to one customer. The `user_id` set in the `config` call is GA4's User-ID feature and is
+**not** a reportable dimension; these properties are.
+
+The values are built in [`user-properties.ts`](./user-properties.ts) and sent with
+`gtag('set', 'user_properties', …)` before the first `config`, so the initial `page_view` carries them.
+When a GTM container id is configured they are also pushed to `dataLayer`, since GTM cannot read gtag's
+internal state.
+
+### Required GA4 Admin registration
+
+None of this is reportable until each name below is registered in **GA4 Admin → Custom definitions** as a
+**User-scoped** dimension, against the exact same string. Collected-but-unregistered data is discarded for
+reporting purposes.
+
+| Dimension name      | User property       | Value                                              |
+| ------------------- | ------------------- | -------------------------------------------------- |
+| `contact_id`        | `contact_id`        | Contact id — the join key back to the platform     |
+| `organization_id`   | `organization_id`   | Organization id                                    |
+| `organization_name` | `organization_name` | Organization name, for readable reports            |
+| `session_kind`      | `session_kind`      | `self`, or `impersonated` while an operator drives |
+| `is_sales_rep`      | `is_sales_rep`      | `true` when the account holds `sales-rep:access`   |
+
+> [!IMPORTANT]
+>
+> **GA does not backfill.** A dimension reports only on data collected after it was registered, so useful
+> history starts on registration day, not on release day. Register them as early as possible.
+
+> [!WARNING]
+>
+> A user-property value is capped at **36 characters** and GA truncates silently.
+> `user-properties.ts` truncates first so the stored value stays predictable — `organization_name` may be
+> cut, which is why `organization_id` is the join key and never a name. It is also why the sales-rep signal
+> is a flag: real role names run 18-20 characters, so a joined role list overflows after one or two and
+> silently drops the rest, including the role worth reporting.
+
+`session_kind` exists because a sales rep impersonating a customer produces events under that customer's
+identity. Reporting on a customer's own behaviour means filtering to `session_kind = self`; without it a
+rep's browsing shows up as the customer's.
+
+To rename a property (a collision with an existing property on the client's GA4 property, for example),
+change `USER_PROPERTY_NAMES` in [`user-properties.ts`](./user-properties.ts) and re-register the dimension
+under the new name — the previously collected data stays under the old one.
 
 # Extending parameters
 

--- a/client-app/modules/google-analytics/index.test.ts
+++ b/client-app/modules/google-analytics/index.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { effectScope, nextTick } from "vue";
+import type { EffectScope } from "vue";
+
+type FakeUserType = {
+  contact?: { id: string; organization?: { id: string; name?: string } };
+  operator?: { userName: string };
+  permissions?: string[];
+};
+
+const hoisted = vi.hoisted(() => ({
+  settings: { trackId: "G-TEST", isEnabled: true, gtmContainerId: "" },
+  hasModuleSettings: true,
+  // Assigned by the mock factory below, which is where a real `ref` can be created.
+  userRef: undefined as unknown as { value: FakeUserType | undefined },
+  addTrackerMock: vi.fn(),
+  useScriptTagMock: vi.fn(),
+}));
+
+// Partial: the rest of the package is pulled in transitively (the logger's `noop`, among others).
+vi.mock("@vueuse/core", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@vueuse/core")>()),
+  useScriptTag: hoisted.useScriptTagMock,
+}));
+
+vi.mock("@/core/composables", () => ({
+  useCurrency: () => ({ currentCurrency: { value: { code: "USD" } } }),
+}));
+
+vi.mock("@/core/composables/useAnalytics", () => ({
+  useAnalytics: () => ({ addTracker: hoisted.addTrackerMock }),
+}));
+
+vi.mock("@/core/composables/useModuleSettings", () => ({
+  useModuleSettings: () => ({
+    getModuleSettings: () => hoisted.settings,
+    hasModuleSettings: {
+      get value() {
+        return hoisted.hasModuleSettings;
+      },
+    },
+  }),
+}));
+
+vi.mock("@/core/globals", () => ({ globals: { cultureName: "en-US" } }));
+
+// Real refs, not stubs: the watcher under test only fires if these track. `user` throws while empty,
+// mirroring the composable it stands in for.
+vi.mock("@/shared/account", async () => {
+  const { ref, computed } = await import("vue");
+  const user = ref<FakeUserType | undefined>(undefined);
+  hoisted.userRef = user;
+
+  return {
+    useUser: () => ({
+      isAuthenticated: computed(() => Boolean(user.value)),
+      user: computed(() => {
+        if (!user.value) {
+          throw new Error("User is missing.");
+        }
+        return user.value;
+      }),
+      organization: computed(() => user.value?.contact?.organization ?? null),
+      operator: computed(() => user.value?.operator ?? null),
+    }),
+  };
+});
+
+vi.mock("./events", () => ({ events: {} }));
+
+const { init } = await import("./index");
+const { USER_PROPERTY_NAMES } = await import("./user-properties");
+
+const SIGNED_IN: FakeUserType = {
+  contact: { id: "contact-1", organization: { id: "org-1", name: "Acme" } },
+  permissions: ["sales-rep:access"],
+};
+
+// `window.gtag` pushes its raw `arguments` object, so a gtag call and a plain data-layer push are both
+// entries in the same array — normalizing lets one assertion cover their relative order.
+function layer(): unknown[][] {
+  return window.dataLayer.map((entry) => (isArrayLike(entry) ? Array.from(entry) : [entry]));
+}
+
+function isArrayLike(value: unknown): value is ArrayLike<unknown> {
+  return typeof value === "object" && value !== null && typeof (value as { length?: unknown }).length === "number";
+}
+
+function indexOfGtagCall(command: string, target?: string): number {
+  return layer().findIndex(([first, second]) => first === command && (target === undefined || second === target));
+}
+
+function lastUserProperties(): Record<string, string | undefined> {
+  const calls = layer().filter(([first, second]) => first === "set" && second === "user_properties");
+
+  return calls[calls.length - 1][2] as Record<string, string | undefined>;
+}
+
+/**
+ * A cleared property has to be *present* and undefined. Reading the key and finding `undefined` proves
+ * nothing — an empty payload reads the same way, and an empty payload is exactly the bug: gtag `set`
+ * merges, so it leaves the previous value untouched.
+ */
+function expectCleared(properties: Record<string, string | undefined>, name: string): void {
+  expect(Object.prototype.hasOwnProperty.call(properties, name)).toBe(true);
+  expect(properties[name]).toBeUndefined();
+}
+
+describe("google-analytics init", () => {
+  let scope: EffectScope;
+
+  // The watcher lives for the app's lifetime by design, so tests own a scope to stop it — otherwise every
+  // earlier test's watcher would still be reacting to the shared user ref.
+  async function initInScope(): Promise<void> {
+    let pending!: Promise<void>;
+    scope.run(() => {
+      pending = init();
+    });
+    await pending;
+  }
+
+  beforeEach(() => {
+    scope = effectScope();
+    hoisted.settings = { trackId: "G-TEST", isEnabled: true, gtmContainerId: "" };
+    hoisted.hasModuleSettings = true;
+    hoisted.userRef.value = SIGNED_IN;
+    hoisted.addTrackerMock.mockReset();
+    hoisted.useScriptTagMock.mockReset();
+    window.dataLayer = [];
+  });
+
+  afterEach(() => {
+    scope.stop();
+  });
+
+  it("sets the user properties before config, so the initial page_view carries them", async () => {
+    await initInScope();
+
+    const setIndex = indexOfGtagCall("set", "user_properties");
+    const configIndex = indexOfGtagCall("config");
+
+    expect(setIndex).toBeGreaterThanOrEqual(0);
+    expect(configIndex).toBeGreaterThanOrEqual(0);
+    expect(setIndex).toBeLessThan(configIndex);
+  });
+
+  it("sends the identity built from the signed-in user", async () => {
+    await initInScope();
+
+    const properties = lastUserProperties();
+
+    expect(properties[USER_PROPERTY_NAMES.contactId]).toBe("contact-1");
+    expect(properties[USER_PROPERTY_NAMES.organizationId]).toBe("org-1");
+    expect(properties[USER_PROPERTY_NAMES.sessionKind]).toBe("self");
+  });
+
+  it("still sets — cleared — properties for an anonymous visitor", async () => {
+    hoisted.userRef.value = undefined;
+
+    await initInScope();
+
+    expect(indexOfGtagCall("set", "user_properties")).toBeGreaterThanOrEqual(0);
+    expectCleared(lastUserProperties(), USER_PROPERTY_NAMES.contactId);
+  });
+
+  it("clears the identity when another tab signs the user out", async () => {
+    await initInScope();
+    expect(lastUserProperties()[USER_PROPERTY_NAMES.contactId]).toBe("contact-1");
+
+    hoisted.userRef.value = undefined;
+    await nextTick();
+
+    expectCleared(lastUserProperties(), USER_PROPERTY_NAMES.contactId);
+    expectCleared(lastUserProperties(), USER_PROPERTY_NAMES.organizationId);
+  });
+
+  it("drops the previous organization when the next identity has none", async () => {
+    await initInScope();
+
+    hoisted.userRef.value = { contact: { id: "contact-2" }, permissions: [] };
+    await nextTick();
+
+    expect(lastUserProperties()[USER_PROPERTY_NAMES.contactId]).toBe("contact-2");
+    expectCleared(lastUserProperties(), USER_PROPERTY_NAMES.organizationId);
+  });
+
+  it("pushes the identity to the data layer for a GTM-only store, which never reaches config", async () => {
+    hoisted.settings = { trackId: "", isEnabled: true, gtmContainerId: "GTM-TEST" };
+
+    await initInScope();
+
+    expect(indexOfGtagCall("config")).toBe(-1);
+    // A plain push, not a gtag call: GTM reads data-layer variables, not gtag's internal state.
+    const pushed = (window.dataLayer as Record<string, string>[]).find(
+      (entry) => entry?.[USER_PROPERTY_NAMES.contactId] === "contact-1",
+    );
+    expect(pushed?.[USER_PROPERTY_NAMES.organizationId]).toBe("org-1");
+  });
+
+  it("does not push to the data layer when no GTM container is configured", async () => {
+    await initInScope();
+
+    const pushed = (window.dataLayer as Record<string, string>[]).find(
+      (entry) => entry?.[USER_PROPERTY_NAMES.contactId] === "contact-1",
+    );
+    expect(pushed).toBeUndefined();
+  });
+
+  it("touches nothing at all when the module is disabled", async () => {
+    hoisted.settings = { trackId: "G-TEST", isEnabled: false, gtmContainerId: "" };
+    const sentinel = { untouched: true };
+    window.dataLayer = [sentinel];
+
+    await initInScope();
+
+    expect(window.dataLayer).toEqual([sentinel]);
+    expect(hoisted.addTrackerMock).not.toHaveBeenCalled();
+  });
+});

--- a/client-app/modules/google-analytics/index.ts
+++ b/client-app/modules/google-analytics/index.ts
@@ -1,4 +1,5 @@
 import { useScriptTag } from "@vueuse/core";
+import { watch } from "vue";
 import { useCurrency } from "@/core/composables";
 import { useAnalytics } from "@/core/composables/useAnalytics";
 import { useModuleSettings } from "@/core/composables/useModuleSettings";
@@ -6,6 +7,7 @@ import { IS_DEVELOPMENT } from "@/core/constants";
 import { globals } from "@/core/globals";
 import { useUser } from "@/shared/account";
 import { MODULE_ID, GOOGLE_ANALYTICS_SETTINGS_MAPPING } from "./constants";
+import { buildUserProperties, userPropertiesKey } from "./user-properties";
 import {
   sendEvent as sendEventFunction,
   productToGtagItem as productToGtagItemFunction,
@@ -45,6 +47,17 @@ export async function init({ extendEvents, extendConfig, extendSet }: InitOption
     useScriptTag(`https://www.googletagmanager.com/gtm.js?id=${gtmContainerId}`);
   }
 
+  const usesDataLayerVariables = Boolean(gtmContainerId);
+
+  // Before the `config` call below, not after: properties set afterwards miss the initial page_view, and
+  // GA never backfills an event that went out untagged.
+  applyUserProperties(usesDataLayerVariables);
+
+  // Login, organization switch and impersonation all end in a full navigation, so this looks redundant —
+  // but `setUser` also replaces the user in place when another tab signs in (userReloadEvent -> fetchUser),
+  // and a one-shot read would keep tagging every later event with the previous identity.
+  watch(userPropertiesKey, () => applyUserProperties(usesDataLayerVariables));
+
   // Register analytics event tracker (works for both GTM-only and GA4)
   const { addTracker } = useAnalytics();
   const { events } = await import("./events");
@@ -81,5 +94,24 @@ export async function init({ extendEvents, extendConfig, extendSet }: InitOption
     }
 
     window.gtag("config", String(trackId), config);
+  }
+}
+
+/**
+ * Tags every subsequent event with the customer identity, so GA4 reports can be filtered down to one
+ * account — `user_id` alone cannot, it is the User-ID feature and not a reportable dimension.
+ *
+ * Called unconditionally, including for an anonymous visitor: the payload always carries every property,
+ * and skipping the call would leave the previous identity in place instead of clearing it.
+ */
+function applyUserProperties(pushToDataLayer: boolean): void {
+  const userProperties = buildUserProperties();
+
+  window.gtag("set", "user_properties", userProperties);
+
+  // GTM reads the data layer, not gtag's internal state, and a GTM-only store configures no measurement id
+  // — so without this it never reaches the `config` branch and never sees the identity at all.
+  if (pushToDataLayer) {
+    window.dataLayer.push({ ...userProperties });
   }
 }

--- a/client-app/modules/google-analytics/user-properties.test.ts
+++ b/client-app/modules/google-analytics/user-properties.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+type FakeUserType = {
+  contact?: { id: string; organization?: { id: string; name?: string } };
+  operator?: { userName: string };
+  permissions?: string[];
+};
+
+const hoisted = vi.hoisted(() => ({
+  state: { isAuthenticated: false, user: undefined as FakeUserType | undefined },
+}));
+
+// Getter-backed stand-ins for the real composable's computeds, including the one that throws when the
+// user has not loaded — that is the behaviour `buildUserProperties` has to guard against.
+vi.mock("@/shared/account", () => ({
+  useUser: () => ({
+    isAuthenticated: {
+      get value() {
+        return hoisted.state.isAuthenticated;
+      },
+    },
+    user: {
+      get value() {
+        if (!hoisted.state.user) {
+          throw new Error("User is missing.");
+        }
+        return hoisted.state.user;
+      },
+    },
+    organization: {
+      get value() {
+        return hoisted.state.user?.contact?.organization ?? null;
+      },
+    },
+    operator: {
+      get value() {
+        return hoisted.state.user?.operator ?? null;
+      },
+    },
+  }),
+}));
+
+const { buildUserProperties, USER_PROPERTY_NAMES, userPropertiesKey } = await import("./user-properties");
+
+function signIn(user: FakeUserType): void {
+  hoisted.state.isAuthenticated = true;
+  hoisted.state.user = user;
+}
+
+const CONTACT: FakeUserType = {
+  contact: { id: "contact-1", organization: { id: "org-1", name: "Acme Industrial" } },
+  permissions: ["storefront:user:view"],
+};
+
+describe("buildUserProperties", () => {
+  beforeEach(() => {
+    hoisted.state.isAuthenticated = false;
+    hoisted.state.user = undefined;
+  });
+
+  // gtag `set` merges, so "no identity" has to be stated as every property cleared. Returning a subset
+  // would leave whoever signed out attached to the anonymous session that follows.
+  it("clears every property for an anonymous visitor", () => {
+    const properties = buildUserProperties();
+
+    const names = Object.values(USER_PROPERTY_NAMES);
+
+    expect(Object.keys(properties)).toHaveLength(names.length);
+    expect(Object.keys(properties)).toEqual(expect.arrayContaining([...names]));
+    expect(Object.values(properties).every((value) => value === undefined)).toBe(true);
+  });
+
+  it("does not throw before the user has loaded", () => {
+    hoisted.state.isAuthenticated = false;
+    hoisted.state.user = undefined;
+
+    expect(() => buildUserProperties()).not.toThrow();
+  });
+
+  it("maps the signed-in identity", () => {
+    signIn(CONTACT);
+
+    expect(buildUserProperties()).toEqual({
+      [USER_PROPERTY_NAMES.contactId]: "contact-1",
+      [USER_PROPERTY_NAMES.organizationId]: "org-1",
+      [USER_PROPERTY_NAMES.organizationName]: "Acme Industrial",
+      [USER_PROPERTY_NAMES.isSalesRep]: "false",
+      [USER_PROPERTY_NAMES.sessionKind]: "self",
+    });
+  });
+
+  it("marks an impersonated session so a rep's browsing can be filtered out", () => {
+    signIn({ ...CONTACT, operator: { userName: "rep@acme.test" } });
+
+    expect(buildUserProperties()[USER_PROPERTY_NAMES.sessionKind]).toBe("impersonated");
+  });
+
+  // Present-but-empty, not absent: an omitted key would leave the previous customer's organization in GA.
+  it("clears the organization for a customer with none", () => {
+    signIn({ contact: { id: "contact-2" } });
+
+    const properties = buildUserProperties();
+
+    expect(properties).toHaveProperty(USER_PROPERTY_NAMES.organizationId);
+    expect(properties[USER_PROPERTY_NAMES.organizationId]).toBeUndefined();
+    expect(properties[USER_PROPERTY_NAMES.organizationName]).toBeUndefined();
+    expect(properties[USER_PROPERTY_NAMES.contactId]).toBe("contact-2");
+  });
+
+  // A flag, not the role list: role names alone overflow the 36-character cap, and which of them survived
+  // then depends on sort order rather than on anything meaningful.
+  it("flags a sales rep by permission, whatever else the account carries", () => {
+    signIn({ ...CONTACT, permissions: ["storefront:user:view", "sales-rep:access", "security:call_api"] });
+
+    expect(buildUserProperties()[USER_PROPERTY_NAMES.isSalesRep]).toBe("true");
+  });
+
+  it("reports a plain customer as false rather than omitting the flag", () => {
+    signIn(CONTACT);
+
+    expect(buildUserProperties()[USER_PROPERTY_NAMES.isSalesRep]).toBe("false");
+  });
+
+  it("treats a missing permission list as not a rep", () => {
+    signIn({ contact: { id: "contact-3" } });
+
+    expect(buildUserProperties()[USER_PROPERTY_NAMES.isSalesRep]).toBe("false");
+  });
+
+  it("truncates a long organization name to GA4's value limit", () => {
+    signIn({ contact: { id: "contact-4", organization: { id: "org-2", name: "N".repeat(50) } } });
+
+    expect(buildUserProperties()[USER_PROPERTY_NAMES.organizationName]).toBe("N".repeat(36));
+  });
+});
+
+describe("userPropertiesKey", () => {
+  beforeEach(() => {
+    hoisted.state.isAuthenticated = false;
+    hoisted.state.user = undefined;
+  });
+
+  it("distinguishes anonymous from signed in", () => {
+    const anonymous = userPropertiesKey();
+
+    signIn(CONTACT);
+
+    expect(userPropertiesKey()).not.toBe(anonymous);
+  });
+
+  it("is stable while the identity is unchanged", () => {
+    signIn(CONTACT);
+
+    expect(userPropertiesKey()).toBe(userPropertiesKey());
+  });
+
+  it("changes when the organization is switched", () => {
+    signIn(CONTACT);
+    const before = userPropertiesKey();
+
+    signIn({ ...CONTACT, contact: { id: "contact-1", organization: { id: "org-9", name: "Other" } } });
+
+    expect(userPropertiesKey()).not.toBe(before);
+  });
+});

--- a/client-app/modules/google-analytics/user-properties.ts
+++ b/client-app/modules/google-analytics/user-properties.ts
@@ -1,0 +1,89 @@
+import { useUser } from "@/shared/account";
+
+/**
+ * GA4 user-scoped custom dimensions.
+ *
+ * Every name here has to be registered by hand in GA4 Admin against the exact same string, and GA does not
+ * backfill: renaming one strands every report already built on it and starts its replacement from empty.
+ * They live in one map so a store whose own property names collide can rename in a single place — see the
+ * registration table in README.md.
+ */
+export const USER_PROPERTY_NAMES = {
+  contactId: "contact_id",
+  organizationId: "organization_id",
+  organizationName: "organization_name",
+  isSalesRep: "is_sales_rep",
+  sessionKind: "session_kind",
+} as const;
+
+/**
+ * Mirrors `SALES_REP_ACCESS_PERMISSION` in the sales-rep module. A duplicated literal rather than an
+ * import: analytics tagging must not make this module depend on a feature module.
+ *
+ * Deliberately raw membership, unlike `useUser().checkPermissions`, which grants an administrator every
+ * permission — a store admin who never opens the hub is not a sales rep, and reporting them as one would
+ * be worse than reporting nothing.
+ */
+const SALES_REP_PERMISSION = "sales-rep:access";
+
+/** Whether the person driving the session is the account owner or someone impersonating them. */
+export type SessionKindType = "self" | "impersonated";
+
+/** Every name in `USER_PROPERTY_NAMES`, `undefined` meaning "clear whatever GA holds for this one". */
+export type UserPropertiesType = Record<string, string | undefined>;
+
+// GA4 truncates a user-property value past this length silently. Doing it here instead keeps the stored
+// value predictable and testable.
+const VALUE_MAX_LENGTH = 36;
+
+/**
+ * The customer identity to tag GA events with — every property, every time.
+ *
+ * gtag `set` MERGES into what it already holds, so a key left out keeps the previous user's value: an
+ * omitted `organization_id` would carry the last customer's organization into the next session, and an
+ * anonymous visitor would keep browsing under the identity of whoever signed out. `undefined` is how GA is
+ * told to drop one, so absent values are sent explicitly rather than skipped.
+ *
+ * `useUser().user` throws when the user has not loaded, so every read sits behind `isAuthenticated`.
+ */
+export function buildUserProperties(): UserPropertiesType {
+  const { isAuthenticated, user, organization, operator } = useUser();
+
+  if (!isAuthenticated.value) {
+    return clearedProperties();
+  }
+
+  const sessionKind: SessionKindType = operator.value ? "impersonated" : "self";
+
+  return {
+    [USER_PROPERTY_NAMES.contactId]: capped(user.value.contact?.id),
+    [USER_PROPERTY_NAMES.organizationId]: capped(organization.value?.id),
+    [USER_PROPERTY_NAMES.organizationName]: capped(organization.value?.name),
+    // A flag rather than the role list: real role names run 18-20 characters, so a joined list overflows
+    // the 36-character cap after one or two and silently drops the rest — including, half the time, the
+    // very role this exists to report.
+    [USER_PROPERTY_NAMES.isSalesRep]: String(user.value.permissions?.includes(SALES_REP_PERMISSION) ?? false),
+    [USER_PROPERTY_NAMES.sessionKind]: sessionKind,
+  };
+}
+
+/**
+ * A watch source for the properties above: the same string while the identity is unchanged. Derived from
+ * `buildUserProperties` rather than listing the fields again, so the two cannot drift.
+ */
+export function userPropertiesKey(): string {
+  return JSON.stringify(buildUserProperties());
+}
+
+/** Every property present and empty — what an anonymous visitor is tagged with, i.e. nothing. */
+function clearedProperties(): UserPropertiesType {
+  return Object.fromEntries(Object.values(USER_PROPERTY_NAMES).map((name) => [name, undefined]));
+}
+
+function capped(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  return value.slice(0, VALUE_MAX_LENGTH);
+}


### PR DESCRIPTION
## Description

Customer-insight widgets on the Sales Rep customer profile — a rep opens a customer and sees what that
customer searched for and which products they viewed ([VCST-5337](https://virtocommerce.atlassian.net/browse/VCST-5337)).

This PR does **not** add those widgets. It closes the one gap that makes them impossible, and it has to
land first — see "Why now".

## Why an analytics change is part of a widgets ticket

The chain behind a widget looks like this:

```
customer profile widget
  └─ salesRepCustomerInsights (SalesRep schema, not built yet)
       └─ backend insights module (not built yet)
            └─ GA4 Data API, filtered to ONE customer
                 └─ requires a user-scoped custom dimension carrying the customer identity
                      └─ the storefront has to send it   ← this PR
```

GA4 has no queryable `userId` dimension. The events the theme already sends carry the search terms and the
viewed products, but nothing that lets a query say "only this customer" — so the endpoint, once written,
would come back empty for every profile. The identity has to arrive as user-scoped custom dimensions, and
the theme sends none: `init()` sets only `user_id`, which is GA4's User-ID feature and cannot be queried.

## Why now, before the backend exists

**GA does not backfill.** A custom dimension only covers data collected after it was registered. If this
ships alongside the backend, the widgets launch empty and stay empty for weeks while history accumulates.
Shipping it first means the data is already there when the endpoint arrives.

## What this does *not* touch

**No events are added or changed.** `view_item`, `search`, `view_search_results`, `add_to_cart` already
carry everything the widgets need; `events.ts` is untouched. The only thing missing was *who*.

Out of scope, to follow once the API contract is agreed: the widgets themselves, the
`salesRepCustomerInsights` query, and the backend module. 

## What it adds

`user-properties.ts` maps `useUser()` state to five GA4 user properties, applied in `index.ts` before the
first `config` call:

| Property | Feeds |
| --- | --- |
| `contact_id` | the join key the backend uses to find one customer's events |
| `organization_id` | the hub is org-scoped, so this is what a profile page filters on |
| `organization_name` | readable output while debugging the backend query |
| `is_sales_rep` | separating rep traffic from customer traffic |
| `session_kind` | `self` / `impersonated` — lets the backend exclude a rep browsing *as* the customer, so the widget does not show the rep their own activity |

Three details are load-bearing and easy to undo by accident:

- **Order.** Properties set after `config` miss the initial `page_view`, and GA never backfills an event
  that went out untagged.
- **Every property, every time.** gtag `set` *merges*, so an omitted key keeps the previous user's value.
  Absent values go out as `undefined` — the explicit clear. Without this, signing out in another tab leaves
  the next anonymous session attributed to the previous customer, and switching to an identity with no
  organization keeps the previous one's `organization_id`. Both would land in a customer's widget as
  someone else's activity.
- **The watcher.** Login, organization switch and impersonation all end in a full navigation, so it looks
  redundant — but `setUser` also replaces the user in place when another tab signs in
  (`userReloadEvent` → `fetchUser`).

`is_sales_rep` is a flag rather than a role list because real role names run 18–20 characters: joined they
overflow GA4's 36-character value cap after one or two, and which survive depends on sort order. On a live
rep account with three roles a joined list silently kept only the first.

## Verified

25 unit tests. Both failure modes above were confirmed to fail the suite before the fix — an earlier
version of the tests passed against the broken code, because reading a key and finding `undefined` is also
what an empty payload looks like.

Manually against a production build (`yarn build && yarn preview`; the module returns early under
`IS_DEVELOPMENT`, so `yarn dev` proves nothing), on a real signed-in rep account:

- `set user_properties` precedes `config` in `dataLayer`
- the GA4 `/g/collect` request for `page_view` carries `up.contact_id`, `up.organization_id`,
  `up.organization_name`, `up.is_sales_rep`, `up.session_kind` — i.e. the data the backend will query is
  actually reaching Google
- an isolated context with no cookies sends all five keys as `undefined` — the clear
- no console errors

## Before the widgets can show anything

1. **Register the five dimensions in GA4 Admin → Custom definitions**, User-scoped, under the exact names
   above. Unregistered properties are collected but not queryable through the Data API, and registration is
   not retroactive. Table in `modules/google-analytics/README.md`.
2. **Enable GA on the store.** The dev store has `GoogleAnalytics4.EnableTracking = false` and no
   measurement id, so the module returns early and nothing is sent at all.
3. Backend module + `salesRepCustomerInsights`, then the widgets.

Side benefit, not the point: with these dimensions registered, existing GA reports also become segmentable
by customer account, which none of them are today.

## References
### Jira-link:
[<!-- Put link to your task in Jira here -->](https://virtocommerce.atlassian.net/browse/VCST-5337?atlOrigin=eyJpIjoiMDczMzFjZDk1NDEwNDIxMzk4MGRhOGRlM2Q2N2UyMTEiLCJwIjoiaiJ9) part 1
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.56.0-pr-2450-a448-a448f992.zip

[VCST-5337]: https://virtocommerce.atlassian.net/browse/VCST-5337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ