### PR TITLE
fix(VCST-5777): render outline icon strokes without non-scaling-stroke

### DIFF
--- a/client-app/ui-kit/components/atoms/icon/vc-icon.vue
+++ b/client-app/ui-kit/components/atoms/icon/vc-icon.vue
@@ -188,10 +188,26 @@ watch(
       }
     }
 
-    @container (width > 56px) {
+    @container (56px < width <= 72px) {
       svg {
         --stroke-bucket: 2.7;
         --size-anchor: 64;
+      }
+    }
+
+    @container (72px < width <= 96px) {
+      svg {
+        --stroke-bucket: 2.7;
+        --size-anchor: 86;
+      }
+    }
+
+    // Past the ladder the stroke grows with the icon instead of staying pinned: no size this
+    // large occurs here, and a hairline on a huge glyph reads anemic.
+    @container (width > 96px) {
+      svg {
+        --stroke-bucket: 2.7;
+        --size-anchor: 96;
       }
     }
 

--- a/client-app/ui-kit/components/atoms/icon/vc-icon.vue
+++ b/client-app/ui-kit/components/atoms/icon/vc-icon.vue
@@ -103,66 +103,95 @@ watch(
 
     container-type: inline-size;
 
+    // Outline icons all share a 24-unit viewBox, so the screen-px stroke values below are
+    // converted to user units by hand — vector-effect: non-scaling-stroke, which did this,
+    // is drawn at half width by Chrome 151.
+    $view-box: 24;
+
     svg :where(path, line, circle, rect, polyline, polygon, ellipse) {
       stroke: currentColor;
-      stroke-width: var(--vc-icon-stroke, var(--stroke-bucket, 1.5));
+      stroke-width: calc(
+        var(--vc-icon-stroke, var(--stroke-bucket, 1.5)) * #{$view-box} / var(--size-anchor, #{$view-box})
+      );
       stroke-linecap: round;
       stroke-linejoin: round;
-      vector-effect: non-scaling-stroke;
     }
 
     // fixed stroke grid keyed to real rendered px
     @container (width <= 10px) {
       svg {
         --stroke-bucket: 1;
+        --size-anchor: 10;
       }
     }
 
     @container (10px < width <= 12px) {
       svg {
         --stroke-bucket: 1.1;
+        --size-anchor: 12;
       }
     }
 
     @container (12px < width <= 14px) {
       svg {
         --stroke-bucket: 1.3;
+        --size-anchor: 14;
       }
     }
 
     @container (14px < width <= 16px) {
       svg {
         --stroke-bucket: 1.5;
+        --size-anchor: 16;
       }
     }
 
     @container (16px < width <= 20px) {
       svg {
         --stroke-bucket: 1.6;
+        --size-anchor: 20;
       }
     }
 
     @container (20px < width <= 24px) {
       svg {
         --stroke-bucket: 1.75;
+        --size-anchor: 24;
       }
     }
 
     @container (24px < width <= 28px) {
       svg {
         --stroke-bucket: 1.8;
+        --size-anchor: 28;
       }
     }
 
     @container (28px < width <= 36px) {
       svg {
         --stroke-bucket: 2;
+        --size-anchor: 32;
       }
     }
 
-    @container (width > 36px) {
+    @container (36px < width <= 44px) {
       svg {
         --stroke-bucket: 2.7;
+        --size-anchor: 40;
+      }
+    }
+
+    @container (44px < width <= 56px) {
+      svg {
+        --stroke-bucket: 2.7;
+        --size-anchor: 48;
+      }
+    }
+
+    @container (width > 56px) {
+      svg {
+        --stroke-bucket: 2.7;
+        --size-anchor: 64;
       }
     }
 


### PR DESCRIPTION
## Problem

Outline icons render at half weight in Chrome 151 on macOS.

## Root cause

Chrome 151 draws `vector-effect: non-scaling-stroke` at exactly half the specified width,
and `VcIcon`'s whole outline stroke grid was built on that property.

Measured on a horizontal line with `stroke-width: 2` (2 CSS px expected):

| Condition | Expected | Actual |
|---|---|---|
| DPR 1 / 2 / 3 | 2.00 px | 1.00 px |
| Zoom 150% | 3.00 px | 1.00 px |

Regular scaling strokes render exactly to spec — only the non-scaling-stroke path is broken.

## Fix

Drop `vector-effect` and convert screen-pixel stroke values to SVG user units ourselves.
Each `@container` bucket now also declares `--size-anchor` — the icon size for which the
conversion is exact — and stroke is computed as:

```scss
stroke-width: calc(var(--vc-icon-stroke, var(--stroke-bucket, 1.5)) * 24 / var(--size-anchor, 24));
```

24 is the shared viewBox of all outline icons. Anchors sit at the top of each bucket
range, where every preset size lands (10 / 14 / 20 / 24 / 40 / 48 / 64); the open-ended
> 36px bucket is split into 36–44 / 44–56 / > 56 so lg, xl and xxl stay exact.

No JavaScript, no user-agent detection, no version gating — the fix does not depend on when
Chrome corrects the bug.

Rejected alternatives: a UA-gated multiplier (needs an upper version bound we cannot know,
and the factor is a constant 2, not devicePixelRatio); runtime feature detection (the
defect is invisible to layout APIs, and isPointInStroke() is inconsistent across engines);
exact CSS division via tan(atan2()) (WebKit computes garbage for atan2() with length
arguments — 19.75px instead of 0.5px at one size, 0px at another).

Verification

- Rendered stroke measured pixel by pixel in Chrome 151 at sizes 10–64: every size matches
  its bucket nominal, max deviation 0.002 px. Arrow-family overrides exact as well.
- Computed values in the Safari 26.5 engine identical to Chrome's.
- yarn lint clean for the touched file, yarn validate:types clean, yarn test:unit 17/17.

Notes

- Public API unchanged: strokeWidth and --vc-icon-stroke keep their screen-pixel meaning.
- The rule assumes a 24-unit viewBox, which all outline icons share (solid icons are not
  affected by it). Documented in a code comment.
- Sizes falling between bucket anchors render up to ~12% thinner than nominal (≤ 0.25 px);
  all preset sizes are pixel-identical to the previous behaviour.
- Above the anchor ladder (> 96px) the stroke scales with the icon rather than staying
  pinned — deliberate, since a hairline on a very large glyph reads anemic. No size that
  large occurs in the repo.

### Before
<img width="1512" height="707" alt="Screenshot 2026-08-25 at 14 34 16" src="https://github.com/user-attachments/assets/54ea3606-c712-4ae1-8efc-ded562146a38" />

### After
<img width="1512" height="719" alt="Screenshot 2026-08-25 at 14 34 54" src="https://github.com/user-attachments/assets/4ecd16db-8eca-4904-b715-cd9692c84f7a" />

## References
### Jira-link:
<!-- Put link to your task in Jira here -->
https://virtocommerce.atlassian.net/browse/VCST-5777
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.56.0-pr-2451-8ba8-8ba8bd04.zip


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped CSS-only change to outline icon rendering in one component; no API or logic changes, with verified pixel parity at preset sizes.
> 
> **Overview**
> Fixes **outline icons rendering at half stroke weight in Chrome 151** by removing `vector-effect: non-scaling-stroke` and manually mapping screen-pixel strokes to SVG user units in `vc-icon.vue`.
> 
> `stroke-width` now uses `calc(--stroke-bucket * 24 / --size-anchor)` (24 = shared outline viewBox). Each size **container query** bucket sets a matching `--size-anchor` so preset sizes (10–64px) stay visually the same; the old single `>36px` bucket is split into finer ranges for lg/xl/xxl, and icons **>96px** let the stroke scale with size instead of staying pinned.
> 
> **`strokeWidth` / `--vc-icon-stroke`** still mean screen pixels; solid icons are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ba8bd04ce94582860d9cbf616015273aa702079. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->