### PR TITLE
fix(VCST-5770): update dompurify and swiper, the two vulnerable runtime dependencies

### DIFF
--- a/client-app/assets/styles/vendors/_swiper.scss
+++ b/client-app/assets/styles/vendors/_swiper.scss
@@ -1,7 +1,7 @@
-@use "swiper/scss";
-@use "swiper/scss/pagination";
-@use "swiper/scss/navigation";
-@use "swiper/scss/thumbs";
+@use "swiper/css";
+@use "swiper/css/pagination";
+@use "swiper/css/navigation";
+@use "swiper/css/thumbs";
 
 :root {
   --swiper-theme-color: theme("colors.primary.500");

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@vueuse/integrations": "^14.3.0",
     "axios": "^1.18.1",
     "barcode-detector": "3.2.1",
-    "dompurify": "^3.4.12",
+    "dompurify": "^3.4.14",
     "firebase": "^12.16.0",
     "graphql": "^16.14.2",
     "graphql-tag": "^2.12.7",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "semver": "^7.8.5",
     "skyflow-js": "2.7.9",
     "sortablejs": "^1.15.7",
-    "swiper": "11.2.10",
+    "swiper": "12.1.2",
     "tw-elements": "^1.1.0",
     "utility-types": "^3.11.0",
     "uuid": "^14.0.1",

--- a/storybook-styles/swiper.scss
+++ b/storybook-styles/swiper.scss
@@ -1,7 +1,7 @@
-@use "swiper/scss";
-@use "swiper/scss/pagination";
-@use "swiper/scss/navigation";
-@use "swiper/scss/thumbs";
+@use "swiper/css";
+@use "swiper/css/pagination";
+@use "swiper/css/navigation";
+@use "swiper/css/thumbs";
 
 :root {
   --swiper-theme-color: var(--color-primary-500);

--- a/yarn.lock
+++ b/yarn.lock
@@ -8318,15 +8318,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:^3.4.12":
-  version: 3.4.12
-  resolution: "dompurify@npm:3.4.12"
+"dompurify@npm:^3.4.14":
+  version: 3.4.14
+  resolution: "dompurify@npm:3.4.14"
   dependencies:
     "@types/trusted-types": "npm:^2.0.7"
   dependenciesMeta:
     "@types/trusted-types":
       optional: true
-  checksum: 10c0/127a13817353d4e20e75a991a9022a04c3af12af7479f68e2b8bee6dbc7330a96edfb8f4ebff96f4f0f24cd43e8dbba46214131f510c3aa87a843bd8b610d0ab
+  checksum: 10c0/feca07ece3805d1d4e33e847c11196888dcdc97b2afe0bb8a2fd11de4e62bfdc434c2403ee3fb3c7771e903325041d062febec6c5518796391fdc0419a90a873
   languageName: node
   linkType: hard
 
@@ -16058,7 +16058,7 @@ __metadata:
     browserslist: "npm:^4.28.6"
     browserslist-to-esbuild: "npm:^2.1.1"
     dependency-cruiser: "npm:^18.1.0"
-    dompurify: "npm:^3.4.12"
+    dompurify: "npm:^3.4.14"
     eslint: "npm:^9.39.5"
     eslint-config-prettier: "npm:^10.1.8"
     eslint-import-resolver-typescript: "npm:^4.4.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14958,10 +14958,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"swiper@npm:11.2.10":
-  version: 11.2.10
-  resolution: "swiper@npm:11.2.10"
-  checksum: 10c0/b7e3a7c79d92ccc62af77744edc376c9aefc771a0abd50c4adf07b5e3450b5da9ca7f84f5809e275ff65e1bc9d4500d930628e84a76fc7f2db403291c69b7fac
+"swiper@npm:12.1.2":
+  version: 12.1.2
+  resolution: "swiper@npm:12.1.2"
+  checksum: 10c0/f2597a67c4d647e367a236735bb7779e2833346b332e6d7b8caf48c6b82da52787959e86f06762983ab82b142958690a0d1b9f6fc5a59170a648949b35cfedd0
   languageName: node
   linkType: hard
 
@@ -16098,7 +16098,7 @@ __metadata:
     storybook: "npm:9.1.20"
     storybook-addon-tag-badges: "npm:^3.1.0"
     storybook-vue3-router: "npm:^7.0.0"
-    swiper: "npm:11.2.10"
+    swiper: "npm:12.1.2"
     tailwindcss: "npm:^3.4.19"
     tw-elements: "npm:^1.1.0"
     typescript: "npm:5.9.3"


### PR DESCRIPTION
## Description

**Why:** two open security advisories sit on packages that ship in the storefront bundle — a **critical prototype pollution** in `swiper` and an **XSS** in `dompurify`. Unlike the rest of our open alerts, these two run in the customer's browser, so they are actually reachable. Both are already fixed upstream; this PR only moves to the patched versions.

`swiper` has no fix on the 11.x line, which is the sole reason for the major bump. `dompurify` is lockfile-only. No application code changes, two commits, independently revertable.

| Alert | Package | Fix | Change |
| --- | --- | --- | --- |
| [#108](https://github.com/VirtoCommerce/vc-frontend/security/code-scanning/108) critical, prototype pollution | swiper 11.2.10 | 12.1.2, no 11.x backport | major bump + 2 stylesheets |
| [#288](https://github.com/VirtoCommerce/vc-frontend/security/code-scanning/288) XSS via detached subtree | dompurify 3.4.12 | 3.4.13 | `^3.4.12` → `^3.4.14`, lockfile only |

### swiper 12

Only one v12 breaking change reaches us: **LESS/SCSS sources were dropped**, so `_swiper.scss` and `storybook-styles/swiper.scss` now `@use "swiper/css"` instead of `swiper/scss`. Both keep their place in the import chain — our `.image-gallery` and `.vc-carousel` overrides still win the cascade (verified by computed style, see below).

**The shipped `.css` files use native CSS nesting** (`&`, nested blocks) where the old `.scss` sources were flat. This matters and is worth a reviewer's attention: `tailwindcss/nesting` in `postcss.config.js` flattens them to **plain descendant selectors, not `:is()`** — so specificity is unchanged and our overrides are unaffected. Confirmed against the browser's resolved stylesheet: 0 nested rules survive, and selectors emit as `.swiper-horizontal .swiper-button-prev`, not `:is(.swiper-horizontal) .swiper-button-prev`. Had postcss emitted `:is()`, vendor rules would have gained specificity and could have clobbered our overrides. Browserslist resolves to Chrome 118+ / Safari 26.3+ / iOS 18.5+, all of which support native nesting natively anyway.

Two new params appear in v12, both inert here:

- **`navigation.addIcons: true`** — cannot inject into our buttons. `navigation.mjs:102` guards on `el.matches('.swiper-button-next,.swiper-button-prev') && !el.querySelector('svg')`; our `VcNavButton` / `vc-carousel__btn` carry neither class and always contain a `VcIcon` svg, so both conditions fail. 0 `.swiper-navigation-icon` in the DOM on every page checked, including a deliberate test against bare `<button>` elements with no svg.
- **`snapToSlideEdge: false`** — opt-in, off. `cssMode: false` everywhere too, so v12's new `.swiper-css-mode` `margin-inline` rules are dead code.

Also noted, no action needed:

- **`.swiper-button-*` is not styled by us, but swiper does stamp its own classes onto our custom nav elements** (`swiper-button-disabled`, `swiper-button-lock`). Checked whether v12's `.swiper-button-lock { display: none }` could hide them — the rule is identical in v11, and computed `display: flex` on both versions.
- **Vendor CSS defaults that changed are unreachable**: `--swiper-navigation-sides-offset` 10px → 4px, and the `swiper-icons` `@font-face` + `::after` arrows replaced by `.swiper-navigation-icon` SVG. All apply only to `.swiper-button-*` elements, of which the app renders none.
- **v12 emits the same slide classes in a different order** (e.g. `swiper-slide-active` before rather than after `swiper-slide-visible`). 0 set differences; nothing in `client-app` matches swiper slide classes or depends on `className` order.
- **RTL / effects / scrollbar / a11y CSS rewrites are unreachable**: the theme ships 13 locales with no RTL language and no `dir="rtl"` handling, and only `Navigation`, `Pagination`, `Thumbs` are imported.

### dompurify

Two call sites: `icons.ts` (`sanitize(raw)`) and `vc-markdown-render.vue` (`USE_PROFILES: { html: true }`). Neither uses hooks or `IN_PLACE`, which is all 3.4.13/3.4.14 changed.

Diffed 3.4.12 against 3.4.14 directly, 47 payloads × both real configs = **94 comparisons, 2 differ**: 3.4.14 *preserves* `vector-effect` and `pointer-events`, i.e. strictly more permissive on two benign SVG presentation attributes. **0 of the 2796 SVGs in `client-app` use either attribute**, so the only behavioural delta in the upgrade is unreachable. 21 XSS vectors (script, `onload`/`onerror`, `javascript:` hrefs, xlink, mXSS via `mglyph`/`noscript`/`noembed`, the detached-subtree CVE class, DOM clobbering, `srcdoc`, `base`) are stripped identically by both.

## Verified

Retested in real Chrome via DevTools, this branch against `vcst-qa-storefront` (same backend), after confirming by CSS/param fingerprint that QA runs swiper 11 and the branch runs 12.

**Prod build vs prod build** (`yarn build` + `yarn preview` against QA prod, so build mode is not a variable) — the headline result: across 49 nodes at ~1400 computed properties each, **0 standard CSS properties differ in value, 0 exist on only one side, 0 root CSS vars differ**. The only remaining entries are the two new params above and Vue's per-instance `v-bind()` hash names.

| Surface | Result |
| --- | --- |
| Homepage: banner slider + 20 product-card carousels | 21/21 initialized, banner next/prev `-1185px` both |
| Catalog: 16 carousels × 6 steps (next/next/prev/slideTo-last/back) | 0/16 differ |
| PDP gallery + thumbs, 2-slide and 4-slide, Navigation+Pagination+Thumbs | identical incl. every computed property |
| Thumb click → main gallery (trusted click) | both `-438px`, activeIndex 1, thumb-active synced |
| Lightbox (tw-elements via swiper attr forwarding) | both open, overlay opacity 1, 800px image, scroll locked |
| Reviews modal (`VcCarousel` + custom prev/next) | identical |
| Real pointer drag (touch, 8-step move) | identical snap to `-216px` |
| Mobile 390×844×2, and 1440→390→1440 round-trip | identical; 4 bullets at mobile, 0 at desktop, no stale bullets either direction |
| 66 slides, `slidesPerView: 4`, `spaceBetween` breakpoints, Navigation | 0/8 steps differ — snapGrid 63, 282px slides, 24px gaps, end clamp, `swiper-button-disabled` at both boundaries |
| `/compare`, search dropdown (32 cards) | identical |
| Icon rendering (dompurify) | 205/205, 149/149, 72/72, 60/60, 59/59 rendered SVG, 0 empty, byte-identical per icon name |
| Live markdown (dompurify `USE_PROFILES`) | 4/4 blocks on `/news` **SHA-256 identical**; only `alt`/`href`/`src`/`title` survive; 0 event handlers, 0 script/iframe/object/embed |

No console errors on either side attributable to swiper or dompurify. `vue-tsc --build --force` 0 errors · 135 test files / 2106 tests · `yarn build` · `yarn storybook:build`.

**Advisory closed — reproduced both ways.** The CVE-2026-27212 PoC (`Array.prototype.indexOf = () => -1`, then `Swiper.extendDefaults(JSON.parse('{"__proto__":{"polluted":"yes"}}'))`) pollutes `Object.prototype` on 11.2.10 and does **not** on 12.1.2. Fix commit `d3e6633` replaced the `noExtend.indexOf(key) < 0` guard in `shared/utils.mjs` with direct key comparisons.

**Residual note, not a blocker.** A variant that overrides `Array.prototype.filter` instead still gets through on the whole 12.x line (12.1.2 through 12.2.0), because `extend()` still builds its key list with `.filter()`. It requires the attacker to already hold `Array.prototype` write access — i.e. prototype pollution is already achieved before Swiper is involved — so it grants nothing new. Swiper 14 removes the exposure by dropping `.filter()` and checking keys inline; worth a look whenever a v14 migration is on the table.

## References
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5770
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.57.0-pr-2457-3c68-3c686607.zip
