### PR TITLE
fix(VCST-5771): harden three untrusted-input sinks in client-app

### DIFF
--- a/client-app/core/utilities/common/index.test.ts
+++ b/client-app/core/utilities/common/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
 import {
   getReturnUrlValue,
+  isSafeRelativeUrl,
   extractHostname,
   truncate,
   appendSuffixToFilename,
@@ -28,55 +29,66 @@ describe("getReturnUrlValue", () => {
     });
   });
 
-  it("should return the value of returnUrl parameter", () => {
-    // Mock location.href
+  it.each([
+    { case: "the returnUrl parameter", href: "http://example.com?returnUrl=/home", expected: "/home" },
+    {
+      case: "the ReturnUrl parameter (case-insensitive)",
+      href: "http://example.com?ReturnUrl=/dashboard",
+      expected: "/dashboard",
+    },
+    { case: "no returnUrl parameter present", href: "http://example.com", expected: null },
+    {
+      case: "returnUrl pointing to a different hostname",
+      href: "http://example.com?returnUrl=http://malicious.com/home",
+      expected: null,
+    },
+    {
+      case: "returnUrl as an absolute URL on the same hostname",
+      href: "http://example.com?returnUrl=http://example.com/home",
+      expected: null,
+    },
+    {
+      case: "returnUrl as a javascript: URL",
+      href: "http://example.com?returnUrl=javascript:alert(1)",
+      expected: null,
+    },
+    {
+      case: "returnUrl as a protocol-relative URL",
+      href: "http://example.com?returnUrl=//malicious.com",
+      expected: null,
+    },
+    {
+      case: "returnUrl with a tab hiding a protocol-relative bypass (browsers strip tabs before parsing)",
+      href: "http://example.com?returnUrl=/%09/malicious.com",
+      expected: null,
+    },
+  ])("should handle $case", ({ href, expected }) => {
     Object.defineProperty(window, "location", {
       configurable: true,
-      value: {
-        href: "http://example.com?returnUrl=/home",
-      },
+      value: { href },
     });
 
-    const result = getReturnUrlValue();
-    expect(result).toBe("/home");
+    expect(getReturnUrlValue()).toBe(expected);
   });
+});
 
-  it("should return the value of ReturnUrl parameter (case-insensitive)", () => {
-    // Mock location.href
-    Object.defineProperty(window, "location", {
-      configurable: true,
-      value: {
-        href: "http://example.com?ReturnUrl=/dashboard",
-      },
-    });
-
-    const result = getReturnUrlValue();
-    expect(result).toBe("/dashboard");
-  });
-
-  it("should return null when returnUrl parameter is not present", () => {
-    // Mock location.href
-    Object.defineProperty(window, "location", {
-      configurable: true,
-      value: {
-        href: "http://example.com",
-      },
-    });
-
-    const result = getReturnUrlValue();
-    expect(result).toBeNull();
-  });
-
-  it("should return null when returnUrl points to a different hostname", () => {
-    Object.defineProperty(window, "location", {
-      configurable: true,
-      value: {
-        href: "http://example.com?returnUrl=http://malicious.com/home",
-      },
-    });
-
-    const result = getReturnUrlValue();
-    expect(result).toBeNull();
+describe("isSafeRelativeUrl", () => {
+  it.each([
+    { case: "a relative path", url: "/account/orders", expected: true },
+    { case: "a relative path with query and hash", url: "/account?tab=orders#top", expected: true },
+    { case: "a protocol-relative URL", url: "//evil.com", expected: false },
+    { case: "an absolute https URL", url: "https://evil.com", expected: false },
+    { case: "a javascript: URL", url: "javascript:alert(1)", expected: false },
+    { case: "a backslash-then-slash bypass", url: "/\\evil.com", expected: false },
+    { case: "a slash-then-backslash bypass", url: "\\/evil.com", expected: false },
+    { case: "a double-backslash bypass", url: "\\\\evil.com", expected: false },
+    { case: "a tab-hidden protocol-relative bypass", url: "/\t/evil.com", expected: false },
+    { case: "a newline-hidden protocol-relative bypass", url: "/\n/evil.com", expected: false },
+    { case: "a carriage-return-hidden protocol-relative bypass", url: "/\r/evil.com", expected: false },
+    { case: "a leading tab hiding a protocol-relative bypass", url: "\t//evil.com", expected: false },
+    { case: "a path with no leading slash", url: "account/orders", expected: false },
+  ])("should return $expected for $case ($url)", ({ url, expected }) => {
+    expect(isSafeRelativeUrl(url)).toBe(expected);
   });
 });
 

--- a/client-app/core/utilities/common/index.ts
+++ b/client-app/core/utilities/common/index.ts
@@ -5,7 +5,7 @@ const RETURN_URL_KEYS = ["returnUrl", "ReturnUrl"] as const;
 
 export function isSafeRelativeUrl(url: string): boolean {
   // Mirrors the browser's tab/newline stripping + backslash normalization, or a hidden "//" could slip past.
-  const normalized = url.replaceAll(/[\t\n\r]/g, "").replaceAll(/\\/g, "/");
+  const normalized = url.replaceAll(/[\t\n\r]/g, "").replaceAll("\\", "/");
   return normalized.startsWith("/") && !normalized.startsWith("//");
 }
 

--- a/client-app/core/utilities/common/index.ts
+++ b/client-app/core/utilities/common/index.ts
@@ -5,7 +5,7 @@ const RETURN_URL_KEYS = ["returnUrl", "ReturnUrl"] as const;
 
 export function isSafeRelativeUrl(url: string): boolean {
   // Mirrors the browser's tab/newline stripping + backslash normalization, or a hidden "//" could slip past.
-  const normalized = url.replace(/[\t\n\r]/g, "").replace(/\\/g, "/");
+  const normalized = url.replaceAll(/[\t\n\r]/g, "").replaceAll(/\\/g, "/");
   return normalized.startsWith("/") && !normalized.startsWith("//");
 }
 

--- a/client-app/core/utilities/common/index.ts
+++ b/client-app/core/utilities/common/index.ts
@@ -3,17 +3,20 @@ import type { RouteLocationRaw, RouteLocationNormalizedLoaded, RouteLocationNorm
 
 const RETURN_URL_KEYS = ["returnUrl", "ReturnUrl"] as const;
 
+export function isSafeRelativeUrl(url: string): boolean {
+  // Mirrors the browser's tab/newline stripping + backslash normalization, or a hidden "//" could slip past.
+  const normalized = url.replace(/[\t\n\r]/g, "").replace(/\\/g, "/");
+  return normalized.startsWith("/") && !normalized.startsWith("//");
+}
+
 export function getReturnUrlValue(): string | null {
-  const { searchParams, origin, hostname } = new URL(location.href);
+  const { searchParams } = new URL(location.href);
 
   // Try each return URL key until we find one
   for (const key of RETURN_URL_KEYS) {
     const returnUrl = searchParams.get(key);
-    if (returnUrl) {
-      const returnUrlObj = new URL(returnUrl, origin);
-      if (returnUrlObj.hostname === hostname) {
-        return returnUrl;
-      }
+    if (returnUrl && isSafeRelativeUrl(returnUrl)) {
+      return returnUrl;
     }
   }
 

--- a/client-app/core/utilities/search/facets.test.ts
+++ b/client-app/core/utilities/search/facets.test.ts
@@ -10,11 +10,32 @@ import {
   getFilterExpressionForAvailableIn,
   getFilterExpressionFromFacets,
   generateFilterExpressionFromFilters,
+  escapeFilterSyntaxValue,
   termFacetToCommonFacet,
   rangeFacetToCommonFacet,
 } from "@/core/utilities";
 import type { RangeFacet, TermFacet, SearchProductFilterResult } from "@/core/api/graphql/types";
 import type { FacetItemType } from "@/core/types";
+
+describe("escapeFilterSyntaxValue", () => {
+  it("returns a plain value unchanged", () => {
+    expect(escapeFilterSyntaxValue("acme")).toBe("acme");
+  });
+
+  it("escapes double quotes", () => {
+    expect(escapeFilterSyntaxValue('acme "corp"')).toBe('acme \\"corp\\"');
+  });
+
+  it("escapes backslashes", () => {
+    expect(escapeFilterSyntaxValue("acme\\corp")).toBe("acme\\\\corp");
+  });
+
+  it("escapes a backslash immediately before a quote without under- or double-escaping", () => {
+    // Regression test: escaping quotes before backslashes would turn `\"` into `\\"`,
+    // leaving the quote unescaped and breaking out of the surrounding quoted string.
+    expect(escapeFilterSyntaxValue('acme\\"corp')).toBe('acme\\\\\\"corp');
+  });
+});
 
 describe("getFilterExpressionFromFacetRange", () => {
   it.each`

--- a/client-app/core/utilities/search/facets.ts
+++ b/client-app/core/utilities/search/facets.ts
@@ -23,7 +23,7 @@ import type { MaybeRef } from "vue";
  * {@link https://github.com/VirtoCommerce/vc-module-experience-api/blob/master/docs/filter-syntax.md#escaping-special-characters}
  */
 export function escapeFilterSyntaxValue(value: string): string {
-  return value.replaceAll(/\\/g, "\\\\").replaceAll(/"/g, String.raw`\"`);
+  return value.replaceAll("\\", "\\\\").replaceAll('"', String.raw`\"`);
 }
 
 /**

--- a/client-app/core/utilities/search/facets.ts
+++ b/client-app/core/utilities/search/facets.ts
@@ -17,6 +17,16 @@ import type { MaybeRef } from "vue";
  */
 
 /**
+ * Escapes backslashes and double quotes per the filter syntax's escaping rules, for embedding
+ * a value inside a filter-syntax expression (a facet filter clause or a quoted search phrase).
+ * Backslashes must be escaped first, otherwise the backslash added for the quote gets re-escaped.
+ * {@link https://github.com/VirtoCommerce/vc-module-experience-api/blob/master/docs/filter-syntax.md#escaping-special-characters}
+ */
+export function escapeFilterSyntaxValue(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+/**
  * Generates a filter expression for category subtree filtering
  * @param payload - Object containing catalogId and optional categoryId
  * @returns A string representing the category subtree filter expression
@@ -89,12 +99,7 @@ export function getFilterExpressionFromFacets(facets: MaybeRef<FacetItemType[]>)
   for (const facet of unref(facets)) {
     const selectedValues: string[] = facet.values
       .filter((item) => item.selected)
-      .map((item) =>
-        item.value
-          // https://github.com/VirtoCommerce/vc-module-experience-api/blob/dev/docs/filter-syntax.md#escaping-special-characters
-          .replace(/\\/g, "\\\\")
-          .replace(/"/g, '\\"'),
-      );
+      .map((item) => escapeFilterSyntaxValue(item.value));
 
     if (!selectedValues.length) {
       continue;
@@ -122,7 +127,7 @@ export function generateFilterExpressionFromFilters(filters: SearchProductFilter
   filters.forEach((filter) => {
     if (filter.termValues?.length) {
       // Handle term filters
-      const escapedTerms = filter.termValues.map((term) => term.value.replace(/\\/g, "\\\\").replace(/"/g, '\\"'));
+      const escapedTerms = filter.termValues.map((term) => escapeFilterSyntaxValue(term.value));
       filterExpressions.push(`"${filter.name}":"${escapedTerms.join('","')}"`);
     } else if (filter.rangeValues?.length) {
       // Handle range filters

--- a/client-app/core/utilities/search/facets.ts
+++ b/client-app/core/utilities/search/facets.ts
@@ -23,7 +23,7 @@ import type { MaybeRef } from "vue";
  * {@link https://github.com/VirtoCommerce/vc-module-experience-api/blob/master/docs/filter-syntax.md#escaping-special-characters}
  */
 export function escapeFilterSyntaxValue(value: string): string {
-  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  return value.replaceAll(/\\/g, "\\\\").replaceAll(/"/g, String.raw`\"`);
 }
 
 /**

--- a/client-app/shared/account/composables/useOrderNavigation.ts
+++ b/client-app/shared/account/composables/useOrderNavigation.ts
@@ -11,7 +11,7 @@ export function useOrderNavigation() {
     const orderRoute = router.resolve({ name: "OrderDetails", params: { orderId: order.id } });
 
     if (browserTarget.value === BrowserTargetType.BLANK) {
-      globalThis.open(orderRoute.href, "_blank")?.focus();
+      globalThis.open(orderRoute.href, "_blank", "noopener")?.focus();
     } else {
       globalThis.location.href = orderRoute.href;
     }

--- a/client-app/shared/account/composables/useUserOrganizations.ts
+++ b/client-app/shared/account/composables/useUserOrganizations.ts
@@ -1,7 +1,7 @@
 import { createGlobalState } from "@vueuse/core";
 import { computed, ref, readonly, onMounted } from "vue";
 import { getOrganizations } from "@/core/api/graphql/account";
-import { Logger } from "@/core/utilities";
+import { Logger, escapeFilterSyntaxValue } from "@/core/utilities";
 import { ContactStatus } from "@/shared/company/types";
 import type { OrganizationFieldsType } from "@/core/api/graphql/account";
 
@@ -22,17 +22,11 @@ function _useUserOrganizations() {
   const currentPage = computed(() => Math.ceil(organizations.value.length / ORGANIZATIONS_PER_PAGE));
   const isShowSearch = computed(() => totalOrganizations.value > SEARCH_THRESHOLD);
 
-  /**
-   * Note: At this moment, Contact/Member query supports filters inside and it breaks encoding.
-   * We need to apply this workaround
-   *  */
-  const formattedSearchPhrase = computed(() => {
-    if (!searchPhrase.value) {
-      return "";
-    }
-    const escaped = searchPhrase.value.replace(/"/g, '\\"');
-    return `"${escaped}"`;
-  });
+  // Note: At this moment, Contact/Member query supports filters inside and it breaks encoding.
+  // We need to apply this workaround by quoting the phrase as a filter-syntax string literal.
+  const formattedSearchPhrase = computed(() =>
+    searchPhrase.value ? `"${escapeFilterSyntaxValue(searchPhrase.value)}"` : "",
+  );
 
   async function loadOrganizations(): Promise<void> {
     if (loading.value || !hasNextPage.value) {


### PR DESCRIPTION
## Description

Closes [VCST-5771](https://virtocommerce.atlassian.net/browse/VCST-5771). CodeQL and Semgrep flagged 5 alerts across 3 places where untrusted input reaches a navigation or query sink. One commit per sink so any single flow can be reverted independently.

- **Return-URL redirect** (`core/utilities/common/index.ts` — `getReturnUrlValue`): only accept genuine same-origin relative paths before assigning `location.href`, instead of a hostname comparison scanners don't recognize as a sanitizer. Normalizes backslashes and ASCII tab/newline first, mirroring the browser's own URL parsing, so a value like `/\t/evil.com` can't collapse into a protocol-relative `//evil.com` after the check already said "safe". Closes #143 (open redirect) and #144 (XSS). This also hardens the OIDC external sign-in redirect in `useIdentityProvider.ts`, which shares the same source function.
- **Order navigation** (`useOrderNavigation.ts`): add `"noopener"` to the `_blank` `window.open` call, closing #139 (missing noopener / reverse tabnabbing). The `router.resolve()`-based `location.href` branch (#140) is left as-is and should be dismissed in code scanning — that URL comes from an internal route name/id, not user input.
- **Organization search** (`useUserOrganizations.ts`): the search phrase escaped `"` but not `\`, so a trailing backslash broke out of the quoted filter-syntax string sent to the Contact/Member query. Closes #142. Extracted the escaping into `escapeFilterSyntaxValue()` in `core/utilities/search/facets.ts` and reused it from the two facet-filter call sites that already implemented the identical rule — three independent copies of the same escaping logic is how this bug happened in the first place.


## References
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5771

[VCST-5771]: https://virtocommerce.atlassian.net/browse/VCST-5771?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.58.0-pr-2460-d04a-d04ac964.zip