### PR TITLE
fix(VCST-5772): clear scanner noise — 3 false positives and 8 dev-script findings

### DIFF
--- a/.semgrep/vc-security.yml
+++ b/.semgrep/vc-security.yml
@@ -42,7 +42,7 @@ rules:
           - pattern: sessionStorage.setItem($KEY, $TOK)
       - metavariable-regex:
           metavariable: $KEY
-          regex: '(?i).*(auth|token|session|jwt|credential).*'
+          regex: "(?i).*(auth|token|session|jwt|credential).*"
     message: >
       Auth/refresh tokens in local/session storage are XSS-exfiltratable. Store the
       refresh token in an HttpOnly cookie and keep the access token in memory only.
@@ -198,12 +198,44 @@ rules:
           - pattern: '$X.addEventListener("message", function ($E) { ... })'
           - pattern: '$X.addEventListener("message", async ($E) => { ... })'
           - pattern: '$X.addEventListener("message", async function ($E) { ... })'
-      # An $E.origin check anywhere in the handler body clears it — including async
-      # handlers, which Semgrep treats as structurally distinct from sync ones.
+      # An $E.origin check anywhere in the handler body clears it — including
+      # async handlers, which Semgrep treats as structurally distinct from sync
+      # ones. Two exclusion shapes are kept side by side (a match is cleared if
+      # it satisfies either): the original bare deep-expression check below
+      # covers a guard written as a plain expression/ternary anywhere in the
+      # body, while the pattern-not-inside further down additionally covers a
+      # guard written inside an `if` condition — the deep-expression operator
+      # placed directly on the body never reaches into a nested if-condition,
+      # which is why a real `if (event.origin !== trusted) return;` guard used
+      # to slip past the bare check alone.
       - pattern-not: '$X.addEventListener("message", ($E) => { <... $E.origin ...> })'
       - pattern-not: '$X.addEventListener("message", function ($E) { <... $E.origin ...> })'
       - pattern-not: '$X.addEventListener("message", async ($E) => { <... $E.origin ...> })'
       - pattern-not: '$X.addEventListener("message", async function ($E) { <... $E.origin ...> })'
+      - pattern-not-inside: |
+          $X.addEventListener("message", ($E) => {
+            ...
+            if (<... $E.origin ...>) { ... }
+            ...
+          })
+      - pattern-not-inside: |
+          $X.addEventListener("message", function ($E) {
+            ...
+            if (<... $E.origin ...>) { ... }
+            ...
+          })
+      - pattern-not-inside: |
+          $X.addEventListener("message", async ($E) => {
+            ...
+            if (<... $E.origin ...>) { ... }
+            ...
+          })
+      - pattern-not-inside: |
+          $X.addEventListener("message", async function ($E) {
+            ...
+            if (<... $E.origin ...>) { ... }
+            ...
+          })
     message: >
       'message' handler must validate event.origin against a trusted allowlist
       before acting on the payload.

--- a/scripts/fix-missing-locales.ts
+++ b/scripts/fix-missing-locales.ts
@@ -21,13 +21,27 @@ function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+// localeFolder/targetFile both trace back to CLI-supplied glob patterns (see
+// check-locales-missing-keys.ts), so before writing the translated result back
+// out, pin the resolved destination to stay inside the resolved locale folder.
+function resolveLocaleJsonPath(localeFolder: string, filePath: string): string {
+  const resolvedFolder = path.resolve(localeFolder);
+  const resolvedFilePath = path.resolve(filePath);
+  // eslint-disable-next-line sonarjs/null-dereference -- false positive: path.resolve always returns a string
+  if (!resolvedFilePath.startsWith(resolvedFolder + path.sep) || path.extname(resolvedFilePath) !== ".json") {
+    throw new Error(`Refusing to write outside the locale folder: "${filePath}"`);
+  }
+  return resolvedFilePath;
+}
+
 async function processTargetFile(targetFilePath: string, keysToFix: MissingKeyType[]): Promise<void> {
   const { originFile, localeFolder } = keysToFix[0];
   const originFilePath = path.join(localeFolder, originFile);
+  const resolvedTargetFilePath = resolveLocaleJsonPath(localeFolder, targetFilePath);
 
   const [originFileContent, targetFileContent] = (await Promise.all([
     fs.promises.readFile(originFilePath, "utf-8").then(JSON.parse),
-    fs.promises.readFile(targetFilePath, "utf-8").then(JSON.parse),
+    fs.promises.readFile(resolvedTargetFilePath, "utf-8").then(JSON.parse),
   ])) as [LocaleDataType, LocaleDataType];
 
   const originLanguage = getLanguageFromFilename(originFile);
@@ -59,7 +73,7 @@ async function processTargetFile(targetFilePath: string, keysToFix: MissingKeyTy
   const missingKeySet = new Set(keysToFix.map((k) => k.key));
   const rebuilt = buildNewLocaleContent(originFileContent, targetFileContent, translationsMap, missingKeySet);
 
-  await fs.promises.writeFile(targetFilePath, JSON.stringify(rebuilt, null, 2));
+  await fs.promises.writeFile(resolvedTargetFilePath, JSON.stringify(rebuilt, null, 2));
 }
 
 export async function fixLocales() {

--- a/scripts/generate-backend-packages-json.js
+++ b/scripts/generate-backend-packages-json.js
@@ -21,10 +21,10 @@ function log(message) {
 // Strip ASCII control characters (CR/LF and raw ESC included) before a value
 // reaches a log sink, so a hostile response body or error message can't forge
 // extra log lines or terminal escape sequences.
-// eslint-disable-next-line no-control-regex -- the control-character range is the point of this filter
-const LOG_UNSAFE_CHARS = /[\x00-\x1f\x7f]+/g;
+// eslint-disable-next-line no-control-regex, sonarjs/duplicates-in-character-class -- control-char range is the point of this filter; \r/\n duplicate part of the \x00-\x1f range on purpose, since CodeQL js/log-injection only recognizes replace() as a sanitizer when \n is an explicit character-class member
+const LOG_UNSAFE_CHARS = /[\r\n\x00-\x1f\x7f]/g;
 function sanitizeForLog(value) {
-  return String(value).replace(LOG_UNSAFE_CHARS, " ");
+  return String(value).replace(LOG_UNSAFE_CHARS, "");
 }
 
 // Read backend URL from .env.local or .env file

--- a/scripts/generate-backend-packages-json.js
+++ b/scripts/generate-backend-packages-json.js
@@ -18,6 +18,15 @@ function log(message) {
   console.log(`${GREEN}${message}${RESET}`);
 }
 
+// Strip ASCII control characters (CR/LF and raw ESC included) before a value
+// reaches a log sink, so a hostile response body or error message can't forge
+// extra log lines or terminal escape sequences.
+// eslint-disable-next-line no-control-regex -- the control-character range is the point of this filter
+const LOG_UNSAFE_CHARS = /[\x00-\x1f\x7f]+/g;
+function sanitizeForLog(value) {
+  return String(value).replace(LOG_UNSAFE_CHARS, " ");
+}
+
 // Read backend URL from .env.local or .env file
 function getBackendUrl() {
   const backendUrl = process.env.APP_BACKEND_URL;
@@ -165,6 +174,7 @@ async function httpRequest(url, options = {}, retries = 5, retryInterval = 5000)
   // Only disable certificate verification for localhost/local development environments
   // This prevents MITM attacks on public endpoints like GitHub
   if (isHttps && isLocalHost(urlObj.hostname)) {
+    // codeql[js/disabling-certificate-validation]: gated to a local/loopback hostname (see isLocalHost above)
     requestOptions.rejectUnauthorized = false;
   }
 
@@ -212,7 +222,7 @@ async function httpRequest(url, options = {}, retries = 5, retryInterval = 5000)
 
 // Get authentication token
 async function getAuthToken(appAuthUrl, username, password) {
-  console.log(`Get-AuthToken: appAuthUrl ${appAuthUrl}`);
+  console.log(`Get-AuthToken: appAuthUrl ${sanitizeForLog(appAuthUrl)}`);
 
   const body = new URLSearchParams({
     username,
@@ -236,7 +246,7 @@ async function getAuthToken(appAuthUrl, username, password) {
 
     return response.access_token;
   } catch (error) {
-    console.error(`Error getting auth token: ${error.message}`);
+    console.error(`Error getting auth token: ${sanitizeForLog(error.message)}`);
     throw error;
   }
 }
@@ -247,7 +257,7 @@ async function fetchJson(url, retries = 5, retryInterval = 5000) {
     const response = await httpRequest(url, {}, retries, retryInterval);
     return typeof response === "string" ? JSON.parse(response) : response;
   } catch (error) {
-    console.error(`Error fetching JSON from ${url}: ${error.message}`);
+    console.error(`Error fetching JSON from ${sanitizeForLog(url)}: ${sanitizeForLog(error.message)}`);
     throw error;
   }
 }
@@ -272,13 +282,13 @@ function getInstalledModules(systeminfo) {
 
   if (!modules) {
     console.error("Error: systeminfo.installedModules is undefined or null");
-    console.error("Response structure:", JSON.stringify(systeminfo, null, 2));
-    console.error("Available properties:", Object.keys(systeminfo || {}));
+    console.error("Response structure:", sanitizeForLog(JSON.stringify(systeminfo, null, 2)));
+    console.error("Available properties:", sanitizeForLog(Object.keys(systeminfo || {}).join(", ")));
     process.exit(1);
   }
   if (!Array.isArray(modules)) {
     console.error("Error: systeminfo.installedModules is not an array");
-    console.error("installedModules value:", modules);
+    console.error("installedModules value:", sanitizeForLog(JSON.stringify(modules)));
     process.exit(1);
   }
 
@@ -392,7 +402,7 @@ async function handleLocalBackend(apiUrl) {
   try {
     systeminfo = await httpRequest(checkModulesUrl, { method: "GET", headers });
   } catch (error) {
-    console.error(`Failed to get system info: ${error.message}`);
+    console.error(`Failed to get system info: ${sanitizeForLog(error.message)}`);
     process.exit(1);
   }
 
@@ -413,7 +423,7 @@ async function handleLocalBackend(apiUrl) {
   const platformVersion = getPropertyCaseInsensitive(systeminfo, "platformVersion");
   if (!platformVersion) {
     console.error("Error: systeminfo.platformVersion is undefined or null");
-    console.error("Available properties:", Object.keys(systeminfo || {}));
+    console.error("Available properties:", sanitizeForLog(Object.keys(systeminfo || {}).join(", ")));
     process.exit(1);
   }
   if (isAlphaVersion(platformVersion)) {
@@ -435,7 +445,9 @@ async function handleRemoteBackend(apiUrl) {
   try {
     return await fetchJson(packagesJsonUrl);
   } catch (error) {
-    console.error(`Failed to get packages.json from ${packagesJsonUrl}: ${error.message}`);
+    console.error(
+      `Failed to get packages.json from ${sanitizeForLog(packagesJsonUrl)}: ${sanitizeForLog(error.message)}`,
+    );
     process.exit(1);
   }
 }
@@ -481,6 +493,6 @@ async function main() {
 try {
   await main();
 } catch (error) {
-  console.error(`Error: ${error.message}`);
+  console.error(`Error: ${sanitizeForLog(error.message)}`);
   process.exit(1);
 }

--- a/scripts/graphql-codegen/generator.ts
+++ b/scripts/graphql-codegen/generator.ts
@@ -35,6 +35,7 @@ if (
   backendUrl.startsWith("https://localhost") &&
   process.env.LOCAL_DEV_ALLOW_INSECURE_TLS === "true"
 ) {
+  // codeql[js/disabling-certificate-validation]: gated above to dev + https://localhost + an explicit opt-in env var, never reachable in CI/prod
   process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
 }
 


### PR DESCRIPTION
## Description
- Fixes the `vc-postmessage-no-origin-check` Semgrep rule: the deep-expression operator never reached into a nested `if`-condition, so the real origin guards in `builder-preview.plugin.ts` and `fcm-service-worker-v1.12.js` slipped past it (false positives [#217](https://github.com/VirtoCommerce/vc-frontend/security/code-scanning/217), [#221](https://github.com/VirtoCommerce/vc-frontend/security/code-scanning/221), [#222](https://github.com/VirtoCommerce/vc-frontend/security/code-scanning/222)).
- Closes the 8 CodeQL findings in `scripts/` (build-only dev tooling, never reaches a browser):
  - TLS bypasses ([#145](https://github.com/VirtoCommerce/vc-frontend/security/code-scanning/145), [#146](https://github.com/VirtoCommerce/vc-frontend/security/code-scanning/146)) are already gated to localhost/dev-only — annotated with CodeQL suppression comments.
  - Log injection ([#148](https://github.com/VirtoCommerce/vc-frontend/security/code-scanning/148)-[#152](https://github.com/VirtoCommerce/vc-frontend/security/code-scanning/152)) — response/error data is now stripped of control characters before it reaches `console.log`/`console.error`.
  - Write-to-file ([#147](https://github.com/VirtoCommerce/vc-frontend/security/code-scanning/147)) — the resolved locale file path is validated to stay inside the locale folder before the translated content is written back.

## References
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5772
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.58.0-pr-2461-ea8a-ea8a8f4d.zip