### PR TITLE
fix(VCST-5848): make links inside a checkbox label clickable

### DIFF
--- a/client-app/ui-kit/components/atoms/checkbox/vc-checkbox.vue
+++ b/client-app/ui-kit/components/atoms/checkbox/vc-checkbox.vue
@@ -263,9 +263,6 @@ function onClick(event: Event) {
   &__label {
     @apply flex items-center min-w-0 min-h-[--size];
 
-    // The invisible input covers the whole container, so a link in the label would never receive
-    // the click. Lift links above it - the native <label> activation behaviour already skips
-    // clicks that land on an interactive descendant, so the checkbox is not toggled by them.
     a[href] {
       @apply relative z-20;
     }

--- a/client-app/ui-kit/components/atoms/checkbox/vc-checkbox.vue
+++ b/client-app/ui-kit/components/atoms/checkbox/vc-checkbox.vue
@@ -263,6 +263,13 @@ function onClick(event: Event) {
   &__label {
     @apply flex items-center min-w-0 min-h-[--size];
 
+    // The invisible input covers the whole container, so a link in the label would never receive
+    // the click. Lift links above it - the native <label> activation behaviour already skips
+    // clicks that land on an interactive descendant, so the checkbox is not toggled by them.
+    a[href] {
+      @apply relative z-20;
+    }
+
     #{$disabled} & {
       @apply opacity-60;
     }


### PR DESCRIPTION
The checkbox renders a full-size invisible input on top of the whole container, so a link in the label never received the click - it only toggled the checkbox. Lift links above the overlay; the native <label> activation behaviour already ignores clicks that land on an interactive descendant, so clicking a link no longer toggles the checkbox.

## Description

## References
### Jira-link:
<!-- Put link to your task in Jira here -->
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.57.0-pr-2465-a6d3-a6d351e0.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CSS stacking tweak in the checkbox atom with no auth, data, or API impact.
> 
> **Overview**
> Fixes **VCST-5848** by ensuring anchor tags in `VcCheckbox` label slot content receive clicks instead of the full-size invisible input (`z-10`) that covers the label.
> 
> Adds a scoped rule on `&__label a[href]` with **`relative z-20`** so links stack above the overlay. Clicks on the link follow normal link behavior and no longer only toggle the checkbox; label activation for the rest of the label is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6d351e0a463929166abea4dbce2d1879b289def. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->