### PR TITLE
VCST-5146: Bump workflow version

### DIFF
--- a/.github/workflows/theme-ci.yml
+++ b/.github/workflows/theme-ci.yml
@@ -254,7 +254,7 @@ jobs:
     needs: ci
     if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
         (github.event_name == 'workflow_dispatch') || (github.base_ref == 'dev') && (github.event_name == 'pull_request') }}
-    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.39
+    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@VCST-5146 #v3.800.39
     with:
       installModules: 'false'
       installCustomModule: 'false'
@@ -268,20 +268,20 @@ jobs:
       testSecretEnvFile: ${{ secrets.VC_TESTING_MODULE_ENV_FILE }}
       sendgridApiKey: ${{ secrets.SENDGRID_APIKEY_4E2E_AUTOTESTS }}
   
-  deploy-cloud:
-    if: ${{ github.ref == 'refs/heads/dev' || github.event_name == 'pull_request'}}
-    needs: ci
-    uses: ./.github/workflows/deploy-cloud.yml
-    with:
-      cmPath: 'theme/artifact.json'
-      artifactKey: 'URL'
-      artifactUrl: ${{ needs.ci.outputs.artifactUrl }}
-      environmentId: ${{ ((github.event_name == 'pull_request' && github.base_ref == 'dev') || github.ref == 'refs/heads/master') && 'qa' || 'dev' }}
-      jiraKeys: ${{ needs.ci.outputs.jira-keys }}
-      forceCommit: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev' }}
-    secrets:
-      REPO_TOKEN: ${{ secrets.REPO_TOKEN }}
-      VIRTOCLOUD_KEY_VCPT_VCST: ${{ secrets.VIRTOCLOUD_KEY_VCPT_VCST }}
-      CLOUD_INSTANCE_BASE_URL: ${{ secrets.CLOUD_INSTANCE_BASE_URL }}
-      CLIENT_ID: ${{ secrets.CLIENT_ID }}
-      CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
+  # deploy-cloud:
+  #   if: ${{ github.ref == 'refs/heads/dev' || github.event_name == 'pull_request'}}
+  #   needs: ci
+  #   uses: ./.github/workflows/deploy-cloud.yml
+  #   with:
+  #     cmPath: 'theme/artifact.json'
+  #     artifactKey: 'URL'
+  #     artifactUrl: ${{ needs.ci.outputs.artifactUrl }}
+  #     environmentId: ${{ ((github.event_name == 'pull_request' && github.base_ref == 'dev') || github.ref == 'refs/heads/master') && 'qa' || 'dev' }}
+  #     jiraKeys: ${{ needs.ci.outputs.jira-keys }}
+  #     forceCommit: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev' }}
+  #   secrets:
+  #     REPO_TOKEN: ${{ secrets.REPO_TOKEN }}
+  #     VIRTOCLOUD_KEY_VCPT_VCST: ${{ secrets.VIRTOCLOUD_KEY_VCPT_VCST }}
+  #     CLOUD_INSTANCE_BASE_URL: ${{ secrets.CLOUD_INSTANCE_BASE_URL }}
+  #     CLIENT_ID: ${{ secrets.CLIENT_ID }}
+  #     CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}

--- a/backend-packages.json
+++ b/backend-packages.json
@@ -24,8 +24,8 @@
           "Version": "3.1005.0"
         },
         {
-          "Id": "VirtoCommerce.ElasticSearch",
-          "Version": "3.806.0"
+          "Id": "VirtoCommerce.ElasticSearch9",
+          "Version": "3.1004.0"
         },
         {
           "Id": "VirtoCommerce.OpenTelemetry",


### PR DESCRIPTION
## Description

## References
### Jira-link:
<!-- Put link to your task in Jira here -->https://virtocommerce.atlassian.net/browse/VCST-5146
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/vc-theme-b2b-vue-2.58.0-pr-2487-7484-7484e58e.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI workflow version pin with no application or secret changes.
> 
> **Overview**
> Updates the **Theme CI** `auto-tests` job to call the shared VirtoCommerce pytest workflow at **v3.800.43** instead of **v3.800.39**. Test inputs (`testSuites`, artifact URLs, secrets) are unchanged; only the reusable workflow pin moves forward.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7484e58e060145e72240ac344f84ff845c79dd86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->